### PR TITLE
fix: add PyYAML to core dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pythonnet>=3.0",
     "pydantic>=2.0",
     "python-dotenv>=1.0",
+    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
dax.py imports yaml at module level but PyYAML was not declared in pyproject.toml, causing ModuleNotFoundError on CI across all Python versions.