### PR TITLE
chore: reset version to 0.1.0.dev0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Tests](https://img.shields.io/badge/tests-547%20passing-brightgreen)
 ![Coverage](https://img.shields.io/badge/coverage-65%25%2B-yellowgreen)
-![Version](https://img.shields.io/badge/version-4.0.0--dev-orange)
+![Version](https://img.shields.io/badge/version-0.1.0--dev-orange)
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pbi-enterprise-cli"
-version = "4.0.0.dev0"
+version = "0.1.0.dev0"
 description = "Power BI enterprise CLI — AI-driven model management, governance, PBIR authoring, XMLA, and DAX testing"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Resets the version from `4.0.0.dev0` to `0.1.0.dev0` in `pyproject.toml` and the README badge.

Prior development was internal. Starting the public version number at 0.1.0 is honest — it will earn its way up as the project matures toward a first stable release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)