### PR TITLE
chore: update all version 4 references to 0.1.0

### DIFF
--- a/.github/actions/pbi-cli-action/action.yml
+++ b/.github/actions/pbi-cli-action/action.yml
@@ -14,7 +14,7 @@ inputs:
     default: "3.11"
 
   pbi-cli-version:
-    description: "pbi-cli-tool version to install (e.g. '>=4.0'). Defaults to latest."
+    description: "pbi-enterprise-cli version to install (e.g. '>=0.1'). Defaults to latest."
     required: false
     default: ""
 
@@ -74,19 +74,19 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
-    - name: Install pbi-cli-tool
+    - name: Install pbi-enterprise-cli
       shell: bash
       run: |
         EXTRAS="${{ inputs.extras }}"
         VERSION="${{ inputs.pbi-cli-version }}"
         if [ -n "$EXTRAS" ] && [ -n "$VERSION" ]; then
-          pip install "pbi-cli-tool[$EXTRAS]$VERSION"
+          pip install "pbi-enterprise-cli[$EXTRAS]$VERSION"
         elif [ -n "$EXTRAS" ]; then
-          pip install "pbi-cli-tool[$EXTRAS]"
+          pip install "pbi-enterprise-cli[$EXTRAS]"
         elif [ -n "$VERSION" ]; then
-          pip install "pbi-cli-tool$VERSION"
+          pip install "pbi-enterprise-cli$VERSION"
         else
-          pip install pbi-cli-tool
+          pip install pbi-enterprise-cli
         fi
 
     - name: Run governance check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Changelog
 
-All notable changes to pbi-cli-tool are documented here.
+All notable changes to pbi-enterprise-cli are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
 ---
 
-## [4.0.0-dev] — 2026-05-09
+## [0.1.0-dev] — 2026-05-10
+
+> First public release. Prior development (v1–v3) was internal only.
 
 ### Added
 - **32 visual types** (up from 16): added KPI, area, stacked bar/column, 100% stacked,
@@ -52,31 +54,3 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - `_url_to_table_name` returns `SalesData` (proper PascalCase) not `Salesdata`
 - `_extract_records({}, None)` returns `[]` not `[{}]`
 
----
-
-## [3.0.0] — 2025-12-01
-
-### Added
-- PBIR GA format backend (`PbirBackend`) — reads/writes `.pbip` project files directly
-- Visual builder with 16 chart types and conditional formatting
-- Governance engine with 4 built-in rules
-- Source profiling for SQL, Excel, CSV
-
----
-
-## [2.0.0] — 2025-06-01
-
-### Added
-- XMLA backend stub
-- DAX test suite (YAML fixtures)
-- Mock backend for CI testing
-- FastAPI REST server (`pbi server`)
-
----
-
-## [1.0.0] — 2025-01-01
-
-### Added
-- Initial release with Desktop (TOM) backend
-- `pbi model`, `pbi measure`, `pbi dax` command groups
-- Basic governance lint (`pbi model lint`)

--- a/src/pbi_cli/__init__.py
+++ b/src/pbi_cli/__init__.py
@@ -1,3 +1,3 @@
 """pbi-cli: Power BI one-stop-shop platform for AI-driven development."""
 
-__version__ = "4.0.0.dev0"
+__version__ = "0.1.0.dev0"

--- a/src/pbi_cli/server/api.py
+++ b/src/pbi_cli/server/api.py
@@ -13,7 +13,7 @@ try:
     from fastapi.responses import FileResponse
     from fastapi.staticfiles import StaticFiles
 
-    app = FastAPI(title="pbi-server", version="4.0.0.dev0", docs_url="/api/docs")
+    app = FastAPI(title="pbi-server", version="0.1.0.dev0", docs_url="/api/docs")
 
     # ── Singleton backend ──────────────────────────────────────────────────
     _backend: Any = None


### PR DESCRIPTION
## Summary

Cleans up every remaining reference to version 4 now that the project has been reset to `0.1.0.dev0`.

### Files changed
| File | Change |
|---|---|
| `src/pbi_cli/__init__.py` | `__version__` 4.0.0.dev0 → 0.1.0.dev0 |
| `src/pbi_cli/server/api.py` | FastAPI `version=` 4.0.0.dev0 → 0.1.0.dev0 |
| `CHANGELOG.md` | `[4.0.0-dev]` → `[0.1.0-dev]`; header updated to `pbi-enterprise-cli`; internal v1–v3 entries removed; note added that prior development was internal |
| `.github/actions/pbi-cli-action/action.yml` | Package name `pbi-cli-tool` → `pbi-enterprise-cli`; version example `>=4.0` → `>=0.1` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)