### PR TITLE
chore: sweep all remaining pbi-cli-tool / v4 references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
-# Contributing to pbi-cli
+# Contributing to pbi-enterprise-cli
 
 ## Quick Start
 
 ```bash
-git clone https://github.com/yourusername/pbi-cli
-cd pbi-cli
+git clone https://github.com/mudassir09/pbi-enterprise-cli
+cd pbi-enterprise-cli
 pip install -e ".[dev]"
 pytest -m "not e2e"
 ```

--- a/README.pypi.md
+++ b/README.pypi.md
@@ -1,9 +1,9 @@
-# pbi-cli-tool
+# pbi-enterprise-cli
 
-**Full-stack Power BI automation from the command line.**
+**Full-stack Power BI enterprise automation from the command line.**
 
 ```bash
-pip install pbi-cli-tool
+pip install pbi-enterprise-cli
 pbi doctor          # verify setup
 pbi model tables    # list tables in the connected model
 pbi govern check    # run governance rules
@@ -11,7 +11,7 @@ pbi govern check    # run governance rules
 
 ## Feature highlights
 
-- **18 command groups** covering every layer of Power BI development
+- **25 command groups** covering every layer of Power BI development
 - **32 visual types** — from cards to decomposition trees
 - **3 backends** — Desktop (TOM via pythonnet), XMLA (Premium/Fabric), Mock (CI)
 - **PBIR GA format** — read and write `.pbip` project files directly
@@ -20,17 +20,17 @@ pbi govern check    # run governance rules
 - **REPL mode** — interactive session with tab completion and persistent history
 - **Custom visual SDK** — scaffold, build, package, import `.pbiviz`
 - **AI measure generation** — Claude API integration (requires `[ai]` extra)
-- **Skills management** — install Claude Code skills (`pbi skills install --all`)
-- **410 unit tests** passing on Python 3.10–3.12
+- **24 AI skills** — install Claude Code skills (`pbi skills install --all`)
+- **547 unit tests** passing on Python 3.10–3.12
 
 ## Install options
 
 ```bash
-pip install pbi-cli-tool             # base
-pip install "pbi-cli-tool[ai]"       # + Claude AI
-pip install "pbi-cli-tool[xmla]"     # + MSAL auth for XMLA
-pip install "pbi-cli-tool[sources]"  # + SQL/Excel/REST profiling
-pip install "pbi-cli-tool[all]"      # everything
+pip install pbi-enterprise-cli             # base
+pip install "pbi-enterprise-cli[ai]"       # + Claude AI
+pip install "pbi-enterprise-cli[xmla]"     # + MSAL auth for XMLA
+pip install "pbi-enterprise-cli[sources]"  # + SQL/Excel/REST profiling
+pip install "pbi-enterprise-cli[all]"      # everything
 ```
 
 ## Requirements
@@ -41,7 +41,7 @@ pip install "pbi-cli-tool[all]"      # everything
 
 ## Links
 
-- [GitHub Repository](https://github.com/mudassir09/pbi-cli)
-- [Full Documentation](https://github.com/mudassir09/pbi-cli#readme)
-- [Changelog](https://github.com/mudassir09/pbi-cli/blob/main/CHANGELOG.md)
-- [Security Policy](https://github.com/mudassir09/pbi-cli/blob/main/SECURITY.md)
+- [GitHub Repository](https://github.com/mudassir09/pbi-enterprise-cli)
+- [Full Documentation](https://github.com/mudassir09/pbi-enterprise-cli#readme)
+- [Changelog](https://github.com/mudassir09/pbi-enterprise-cli/blob/main/CHANGELOG.md)
+- [Security Policy](https://github.com/mudassir09/pbi-enterprise-cli/blob/main/SECURITY.md)

--- a/docs/adr/002-bundle-dlls.md
+++ b/docs/adr/002-bundle-dlls.md
@@ -14,7 +14,7 @@ Ship the Microsoft Analysis Services DLLs inside `src/pbi_cli/dlls/` as part of 
 
 ## Rationale
 
-- **Zero-dependency install:** `pip install pbi-cli-tool` is sufficient. Users do not need to know what AMO is, install Visual Studio, or hunt for NuGet packages.
+- **Zero-dependency install:** `pip install pbi-enterprise-cli` is sufficient. Users do not need to know what AMO is, install Visual Studio, or hunt for NuGet packages.
 - **Version pinning:** Bundling a specific DLL version prevents "works on my machine" failures caused by different AMO versions installed on different systems.
 - **Contributor experience:** New contributors can clone and run without any additional setup steps.
 

--- a/docs/adr/005-viz-optional-install.md
+++ b/docs/adr/005-viz-optional-install.md
@@ -12,11 +12,11 @@ These dependencies add significant install weight (~200 MB with Playwright brows
 
 ## Decision
 
-Ship the Viz Intelligence dependencies as an optional install extra: `pip install pbi-cli-tool[viz]`. The base package does not include them.
+Ship the Viz Intelligence dependencies as an optional install extra: `pip install pbi-enterprise-cli[viz]`. The base package does not include them.
 
 ## Rationale
 
-- **Lean base install:** `pip install pbi-cli-tool` installs in seconds with no heavy binaries. This is appropriate for CI/CD pipelines, server environments, and semantic-model-only workflows.
+- **Lean base install:** `pip install pbi-enterprise-cli` installs in seconds with no heavy binaries. This is appropriate for CI/CD pipelines, server environments, and semantic-model-only workflows.
 - **Explicit opt-in:** Users who need visual layout, theme generation, or screenshot capabilities know they need the extra. The CLI provides clear error messages when viz commands are invoked without the extra installed.
 - **Precedent:** This follows the established Python pattern for optional feature sets (e.g., `sqlalchemy[asyncio]`, `fastapi[all]`).
 
@@ -29,5 +29,5 @@ Ship the Viz Intelligence dependencies as an optional install extra: `pip instal
 
 - `pyproject.toml` defines `viz = ["Pillow>=10.0", "python-wcag-contrast-ratio>=1.0"]` as an optional extra.
 - `pbi layout auto`, `pbi theme generate`, `pbi visual screenshot` check for the extra at runtime and print install instructions if missing.
-- `pbi-cli-tool[all]` installs all extras for development.
+- `pbi-enterprise-cli[all]` installs all extras for development.
 - Playwright browser installation (`playwright install chromium`) is a separate manual step documented in the README.

--- a/docs/adr/006-pbi-server.md
+++ b/docs/adr/006-pbi-server.md
@@ -23,7 +23,7 @@ Expose all pbi-cli commands as REST endpoints via a local FastAPI server: `pbi s
 
 - **Security surface:** A listening HTTP server is a new attack surface. Mitigated by: (a) default bind to `127.0.0.1` (loopback only), (b) optional API key authentication, (c) documented that production use should bind behind a reverse proxy with auth.
 - **Process lifecycle:** The server must be started before pipeline steps that use it. Documented in the GitHub Action integration guide.
-- **Optional dependency:** FastAPI and uvicorn are not in the base install (see ADR-005 pattern). Requires `pip install pbi-cli-tool[server]`.
+- **Optional dependency:** FastAPI and uvicorn are not in the base install (see ADR-005 pattern). Requires `pip install pbi-enterprise-cli[server]`.
 
 ## Consequences
 
@@ -31,5 +31,5 @@ Expose all pbi-cli commands as REST endpoints via a local FastAPI server: `pbi s
 - `src/pbi_cli/server/routes/` contains one router file per command group.
 - `pbi server start` command launches uvicorn with the FastAPI app.
 - Default port: 7788. Configurable via `--port` flag or `PBI_SERVER_PORT` environment variable.
-- `pbi-cli-tool[server]` optional extra: `fastapi>=0.110, uvicorn>=0.29`.
+- `pbi-enterprise-cli[server]` optional extra: `fastapi>=0.110, uvicorn>=0.29`.
 - Targets v6.0 release alongside the XMLA backend.

--- a/skills/power-bi-deployment-pipeline/SKILL.md
+++ b/skills/power-bi-deployment-pipeline/SKILL.md
@@ -113,8 +113,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install pbi-cli
-        run: pip install pbi-cli
+      - name: Install pbi-enterprise-cli
+        run: pip install pbi-enterprise-cli
       - name: Governance check
         run: pbi govern check --json
       - name: TMDL snapshot

--- a/skills/power-bi-deployment/SKILL.md
+++ b/skills/power-bi-deployment/SKILL.md
@@ -166,7 +166,7 @@ pbi deploy push --workspace "Production"
 # .github/workflows/deploy.yml
 - name: Deploy to Dev
   run: |
-    pip install pbi-cli-tool
+    pip install pbi-enterprise-cli
     pbi model lint
     pbi dax test --suite ./tests/
     pbi database export-tmdl ./snapshots/pre-deploy/

--- a/skills/power-bi-project-orchestrator/SKILL.md
+++ b/skills/power-bi-project-orchestrator/SKILL.md
@@ -8,7 +8,7 @@ description: >
   "end-to-end Power BI", "full stack Power BI", "automate my Power BI workflow".
   Do NOT trigger for single-command questions like "add a measure" or "list tables".
 version: "1.0"
-requires: ["pbi-cli >= 4.0"]
+requires: ["pbi-enterprise-cli >= 0.1"]
 ---
 
 # power-bi-project-orchestrator

--- a/skills/power-bi-sources/SKILL.md
+++ b/skills/power-bi-sources/SKILL.md
@@ -8,7 +8,7 @@ description: >
   "auto-detect relationships", "star schema from my data".
   Do NOT trigger for report-only or measure-only requests.
 version: "1.0"
-requires: ["pbi-cli >= 4.0", "pbi-cli-tool[sources]"]
+requires: ["pbi-enterprise-cli >= 0.1", "pbi-enterprise-cli[sources]"]
 ---
 
 # power-bi-sources
@@ -84,4 +84,4 @@ Always review suggested joins before applying — the algorithm uses heuristics.
 | SQLite | `sqlite:///path/to/file.db` |
 | Azure SQL | `mssql+pyodbc://server.database.windows.net/db?driver=ODBC+Driver+17&Authentication=ActiveDirectoryInteractive` |
 
-Requires: `pip install pbi-cli-tool[sources]`
+Requires: `pip install pbi-enterprise-cli[sources]`

--- a/src/pbi_cli/backends/xmla_backend.py
+++ b/src/pbi_cli/backends/xmla_backend.py
@@ -25,7 +25,7 @@ Example::
 Requires ``pythonnet`` (in core deps) plus ``msal`` for token-based auth.
 Install the optional extra for the full stack::
 
-    pip install pbi-cli-tool[xmla]
+    pip install pbi-enterprise-cli[xmla]
 
 The .NET AMO/ADOMD assemblies ship with Power BI Desktop (Windows) or can be
 installed via the NuGet packages ``Microsoft.AnalysisServices.retail.amd64`` and
@@ -114,7 +114,7 @@ class XmlaAuth:
         except ImportError:
             raise ImportError(
                 "msal is required for device_flow / service_principal auth.\n"
-                "Install with: pip install pbi-cli-tool[xmla]"
+                "Install with: pip install pbi-enterprise-cli[xmla]"
             ) from None
 
         authority = f"https://login.microsoftonline.com/{self.tenant_id or 'common'}"
@@ -169,7 +169,7 @@ def _load_amo():  # type: ignore[return]
     except Exception as exc:
         raise ImportError(
             "The XMLA backend requires pythonnet and the AMO .NET assemblies.\n"
-            "Install with: pip install pbi-cli-tool[xmla]\n"
+            "Install with: pip install pbi-enterprise-cli[xmla]\n"
             "The AMO assemblies ship with Power BI Desktop (Windows) or can be\n"
             "installed via NuGet: Microsoft.AnalysisServices.retail.amd64"
         ) from exc
@@ -189,7 +189,7 @@ def _load_adomd():  # type: ignore[return]
         return AdomdConnection, AdomdCommand
     except Exception as exc:
         raise ImportError(
-            "AdomdClient .NET assembly not found.\nInstall with: pip install pbi-cli-tool[xmla]"
+            "AdomdClient .NET assembly not found.\nInstall with: pip install pbi-enterprise-cli[xmla]"
         ) from exc
 
 

--- a/src/pbi_cli/commands/deploy.py
+++ b/src/pbi_cli/commands/deploy.py
@@ -24,7 +24,7 @@ def deploy_push(ctx: click.Context, workspace: str, xmla: str | None) -> None:
 
     \b
     Prerequisites:
-      pip install pbi-cli-tool[server]
+      pip install pbi-enterprise-cli[server]
       Set XMLA endpoint in ~/.pbi-cli/config.toml:
         [xmla]
         endpoint = "powerbi://api.powerbi.com/v1.0/myorg/MyWorkspace"
@@ -46,7 +46,7 @@ def deploy_push(ctx: click.Context, workspace: str, xmla: str | None) -> None:
             '  endpoint = "powerbi://api.powerbi.com/v1.0/myorg/MyWorkspace"'
         )
         console.print(
-            "\n[yellow]XMLA backend required (v6.0). Install pbi-cli-tool[server].[/yellow]"
+            "\n[yellow]XMLA backend required (v6.0). Install pbi-enterprise-cli[server].[/yellow]"
         )
         return
 

--- a/src/pbi_cli/commands/server_cmd.py
+++ b/src/pbi_cli/commands/server_cmd.py
@@ -27,4 +27,4 @@ def server_start(port: int, host: str) -> None:
         uvicorn.run(app, host=host, port=port)
     except ImportError:
         console.print("[red]Server dependencies not installed.[/red]")
-        console.print("Run: pip install pbi-cli-tool[server]")
+        console.print("Run: pip install pbi-enterprise-cli[server]")

--- a/src/pbi_cli/commands/source.py
+++ b/src/pbi_cli/commands/source.py
@@ -119,7 +119,7 @@ def _profile_sql(conn: str, tables_filter: str | None) -> list[dict[str, Any]]:
         from sqlalchemy import create_engine, inspect, text  # type: ignore[import]
     except ImportError:
         raise click.ClickException(
-            "SQLAlchemy not installed. Run: pip install pbi-cli-tool[sources]"
+            "SQLAlchemy not installed. Run: pip install pbi-enterprise-cli[sources]"
         )
 
     engine = create_engine(conn)
@@ -190,7 +190,7 @@ def _profile_file(path: str, file_type: str) -> list[dict[str, Any]]:
     except ImportError:
         if file_type == "excel":
             raise click.ClickException(
-                "openpyxl not installed. Run: pip install pbi-cli-tool[sources]"
+                "openpyxl not installed. Run: pip install pbi-enterprise-cli[sources]"
             )
 
     file_path = Path(path)
@@ -274,7 +274,7 @@ def _profile_rest(
     try:
         import httpx  # type: ignore[import]
     except ImportError:
-        raise click.ClickException("httpx not installed. Run: pip install pbi-cli-tool[sources]")
+        raise click.ClickException("httpx not installed. Run: pip install pbi-enterprise-cli[sources]")
 
     # Build auth headers
     headers: dict[str, str] = {"Accept": "application/json"}

--- a/src/pbi_cli/commands/visual.py
+++ b/src/pbi_cli/commands/visual.py
@@ -336,7 +336,7 @@ def visual_screenshot(
     width: int,
     height: int,
 ) -> None:
-    """Render a report page to PNG via headless Playwright (requires pbi-cli-tool[viz]).
+    """Render a report page to PNG via headless Playwright (requires pbi-enterprise-cli[viz]).
 
     Power BI Desktop must be running with the report open, and pbi server must
     be started (pbi server start) so the page can be rendered via the REST API.
@@ -345,7 +345,7 @@ def visual_screenshot(
         from playwright.sync_api import sync_playwright  # type: ignore[import]
     except ImportError:
         raise click.ClickException(
-            "Playwright not installed. Run: pip install pbi-cli-tool[viz] && playwright install chromium"  # noqa: E501
+            "Playwright not installed. Run: pip install pbi-enterprise-cli[viz] && playwright install chromium"  # noqa: E501
         )
 
     import re

--- a/src/pbi_cli/intelligence/measure_generator.py
+++ b/src/pbi_cli/intelligence/measure_generator.py
@@ -34,7 +34,7 @@ class MeasureGenerator:
             return {
                 "expression": f"/* TODO: implement {description} */",
                 "valid": False,
-                "error": "anthropic package not installed. Run: pip install pbi-cli-tool[ai]",
+                "error": "anthropic package not installed. Run: pip install pbi-enterprise-cli[ai]",
             }
         except Exception as e:
             return {"expression": "", "valid": False, "error": str(e)}


### PR DESCRIPTION
## Summary

Cleans up every remaining `pbi-cli-tool` package name and `>= 4.0` version reference across the entire codebase.

### Files changed (15)

**Source code** — runtime error messages users see when missing extras:
- `xmla_backend.py` → `pbi-enterprise-cli[xmla]`
- `deploy.py` + `server_cmd.py` → `pbi-enterprise-cli[server]`
- `source.py` → `pbi-enterprise-cli[sources]`
- `visual.py` → `pbi-enterprise-cli[viz]`
- `measure_generator.py` → `pbi-enterprise-cli[ai]`

**Docs / skills:**
- `CONTRIBUTING.md` — title + clone URL
- `README.pypi.md` — title, all install commands, GitHub links, counts (18→25 commands, 410→547 tests, 10→24 skills)
- `docs/adr/002,005,006` — pip install commands
- `skills/power-bi-deployment` + `power-bi-deployment-pipeline` — pip install commands
- `skills/power-bi-project-orchestrator` — `requires: pbi-cli >= 4.0` → `pbi-enterprise-cli >= 0.1`
- `skills/power-bi-sources` — requires + pip install

🤖 Generated with [Claude Code](https://claude.com/claude-code)