### PR TITLE
fix(mcp): drop CliRunner(mix_stderr=) removed in Click 8.2

### DIFF
--- a/src/pbi_cli/mcp_server.py
+++ b/src/pbi_cli/mcp_server.py
@@ -112,7 +112,9 @@ class McpServer:
             from pbi_cli.cli import cli as root
 
             argv = self._cli_prefix + [str(a) for a in (args.get("args") or [])]
-            result = CliRunner(mix_stderr=True).invoke(root, argv)
+            # NB: no mix_stderr kwarg — removed in Click 8.2. These commands write
+            # to stdout (rich Console), which result.output captures on all versions.
+            result = CliRunner().invoke(root, argv)
             return {"exit_code": result.exit_code, "output": result.output}
         if name == "model_info":
             return b.model_info()


### PR DESCRIPTION
CI (Python 3.10–3.13) failed on `test_run_cli_passthrough_executes`: CI resolves Click ≥8.2, where `CliRunner.__init__` no longer accepts `mix_stderr`. The `run_cli` MCP passthrough tool therefore raised `TypeError`, and the test tried to JSON-parse the resulting `"Error: ..."` string (`JSONDecodeError`).

Fix: use plain `CliRunner()`. These commands write to stdout via rich Console, which `result.output` captures on all supported Click versions (verified locally on 8.1.8).

927 tests pass, coverage 80.2%, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)