### PR TITLE
feat(backend): fabric backend — edit a live semantic model from any OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — `fabric` backend: edit a live semantic model from any OS
+- New `--backend fabric` writes measures to a **published** Fabric semantic model
+  without Windows or XMLA. It downloads the model's TMDL definition (getDefinition),
+  edits it with the pure-Python TMDL writer, and pushes it back (updateDefinition LRO):
+  - `pbi --backend fabric --workspace <ws> --dataset <ds> measure add/update/delete ...`
+  - Ids also read from `PBI_FABRIC_WORKSPACE` / `PBI_FABRIC_DATASET`.
+- Closes the write gap the `rest` backend left (rest is read-only). Structural edits
+  (tables, relationships, partitions) still use the desktop/xmla backends.
+- New `backends/fabric_backend.py` (subclasses `FileBackend`, so all read/edit logic
+  is reused) and faithful `fabric_api.encode_parts`/`decode_parts` round-trip helpers
+  that preserve `.platform` (the older command helper dropped dotfiles).
+- New global `--workspace` / `--dataset` flags.
+
 ### Added — `pbi lakehouse`: first-class Lakehouse table operations
 - `pbi lakehouse list` — list lakehouses in a workspace.
 - `pbi lakehouse tables` — list Delta tables (handles the `data`-keyed, paged response).

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ pbi ask "top 10 customers by revenue"          # English → DAX → results (re
 
 Honesty about coverage, so you can judge fit:
 
-- **Deep today (the moat):** the semantic-model layer — modelling, DAX authoring/testing/lint, governance + BPA, RLS, report (PBIR) authoring & analysis, TMDL diff/snapshot, docs/lineage, and CI gating. This is production-grade and best-in-class.
+- **Deep today (the moat):** the semantic-model layer — modelling, DAX authoring/testing/lint, governance + BPA, RLS, report (PBIR) authoring & analysis, TMDL diff/snapshot, docs/lineage, and CI gating. This is production-grade and best-in-class. Live measure edits now work **from any OS** via the `fabric` backend (no Windows/XMLA).
 - **Solid:** Fabric platform *lifecycle* — item CRUD (any type), workspaces, git sync, deployment pipelines, OneLake files, capacity ops, jobs; **T-SQL against Warehouse/Lakehouse SQL endpoints** (`pbi sql query`); **Lakehouse table ops** (`pbi lakehouse` — list/tables/load/maintenance); **notebook runs** (`pbi notebook` — parameterised run, status, `.ipynb` export/import).
 - **Emerging (item-level only, ergonomics in progress):** data-pipeline (Data Factory) run monitoring and Dataflows Gen2 mashups — reachable via `pbi fabric item`/`pbi fabric job`, dedicated commands still being built.
 - **Not yet:** Eventstream / Eventhouse / KQL / Real-Time Intelligence and Spark environments.
@@ -161,10 +161,10 @@ If your work is **Power BI semantic models, governance, and analytics**, this is
 
 ---
 
-## Five-Backend Architecture
+## Six-Backend Architecture
 
 <div align="center">
-  <img src="docs/assets/architecture.svg" alt="Three-backend architecture" width="100%"/>
+  <img src="docs/assets/architecture.svg" alt="Backend architecture" width="100%"/>
 </div>
 
 | Backend | When to use | Requires |
@@ -173,15 +173,23 @@ If your work is **Power BI semantic models, governance, and analytics**, this is
 | `xmla` | Power BI Premium or Microsoft Fabric — no Desktop | Windows + MSAL (`[xmla]` extra) |
 | `file` | TMDL/PBIP folders straight from the repo — governance, lint, docs, diff | Nothing — works on Linux/macOS |
 | `rest` | Live DAX against any published dataset (executeQueries API) | A token — works on Linux/macOS |
+| `fabric` | **Edit measures on a live model from any OS** — TMDL round-trip via the Item Definition API (no Windows, no XMLA) | A token — works on Linux/macOS |
 | `mock` | CI pipelines, unit tests, demos | Nothing — works on Linux/macOS |
 
 ```bash
 # Swap with --backend
-pbi --backend file --path . govern check --fail-on error   # real artifacts, any OS
-pbi --backend rest dax query "EVALUATE TOPN(10, Sales)"     # live Fabric, any OS
-pbi --backend xmla model tables                             # Fabric without Desktop
-pbi --backend desktop measure list                          # local Desktop (default)
+pbi --backend file --path . govern check --fail-on error          # real artifacts, any OS
+pbi --backend rest dax query "EVALUATE TOPN(10, Sales)"            # live DAX, any OS
+pbi --backend fabric --workspace <ws> --dataset <ds> \
+    measure add Sales "Margin %" "DIVIDE([Profit],[Revenue])"     # live WRITE, any OS
+pbi --backend xmla model tables                                   # Fabric without Desktop
+pbi --backend desktop measure list                                # local Desktop (default)
 ```
+
+> **The `fabric` backend** downloads the model's TMDL definition, applies the edit
+> with the pure-Python TMDL writer, and pushes it back via `updateDefinition` — so
+> `measure add/update/delete` against a *published* model no longer needs Windows.
+> Structural edits (tables, relationships, partitions) still use `desktop`/`xmla`.
 
 ---
 
@@ -333,8 +341,9 @@ Scaffold all of this in one command: **`pbi init`**.
 
 | Flag | Purpose |
 |---|---|
-| `--backend desktop\|xmla\|mock\|file\|rest` | Select backend (default: `desktop`) |
+| `--backend desktop\|xmla\|mock\|file\|rest\|fabric` | Select backend (default: `desktop`) |
 | `--path <folder>` | TMDL/PBIP project folder (file backend) |
+| `--workspace <id>` / `--dataset <id>` | Fabric workspace + semantic-model id (fabric backend) |
 | `--dry-run` | Preview changes without applying them |
 | `--json` / `--yaml` | Machine-readable output |
 | `--connection <name>` | Use a named connection from `~/.pbi-cli/connections.json` |

--- a/RECOMMENDATIONS.md
+++ b/RECOMMENDATIONS.md
@@ -13,7 +13,7 @@
 >   - ⛔ **Not started:** Eventstream / Eventhouse / KQL / Real-Time Intelligence, Spark environments.
 >
 >   *Caveat: a ✅ elsewhere in this doc historically meant "an item of that type can be CRUD'd", which is not the same as a usable engineering command.*
-> - ✅ **§2 Cross-platform** — `file` backend (TMDL/PBIP) + `rest` backend (executeQueries); pure-Python XMLA client remains future work
+> - ✅ **§2 Cross-platform** — `file` backend (TMDL/PBIP) + `rest` backend (executeQueries) + `fabric` backend (live **measure writes** any-OS via the Item Definition API, added 2026-06-21); a full pure-Python XMLA read/write client remains future work
 > - ✅ **§3 Performance** — Direct Lake diagnostics (`fabric directlake`); VertiPaq/benchmark harness still ride on existing `pbi trace`/`benchmark`
 > - ✅ **§4 DAX tooling** — `dax format`, `dax lint`, `dax coverage` (impact analysis already existed as `model impact`)
 > - ✅ **§5 Power Query** — `pbi pquery list/get/folding-check/lint`

--- a/src/pbi_cli/backends/fabric_backend.py
+++ b/src/pbi_cli/backends/fabric_backend.py
@@ -1,0 +1,101 @@
+"""FabricDefinitionBackend — edit a *live* Fabric semantic model from any OS.
+
+The `rest` backend can read a published model and run DAX, but it cannot
+*write*; live writes otherwise need Windows + XMLA + TOM. This backend closes
+that gap for the common case (measure add/update/delete) using the Fabric Item
+Definition API: it downloads the model's TMDL definition into a temp folder,
+reuses the pure-Python `FileBackend` to read and edit it, then pushes the result
+back with ``updateDefinition`` (a long-running operation). No Windows, no .NET.
+
+Heavier structural edits (tables, relationships, partitions) are intentionally
+out of scope — use the desktop/xmla backends for those.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from pbi_cli import fabric_api as _fab
+from pbi_cli.backends.file_backend import FileBackend
+
+
+class FabricDefinitionBackend(FileBackend):
+    """Round-trip a Fabric semantic model's TMDL definition over REST."""
+
+    def __init__(self, workspace_id: str, item_id: str, token: str | None = None) -> None:
+        if not workspace_id or not item_id:
+            raise ValueError("FabricDefinitionBackend requires workspace_id and item_id.")
+        self.workspace_id = workspace_id
+        self.item_id = item_id
+        self._token = token or _fab.get_token()
+        self._tmpdir = Path(tempfile.mkdtemp(prefix="pbi-fabric-"))
+        try:
+            self._download_definition()
+            super().__init__(path=self._tmpdir)
+        except Exception:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+            raise
+
+    # --- REST plumbing ---
+
+    def _base(self) -> str:
+        return (
+            f"{_fab.FABRIC_API_BASE}/workspaces/{self.workspace_id}"
+            f"/semanticModels/{self.item_id}"
+        )
+
+    def _download_definition(self) -> None:
+        result = _fab.poll_lro(
+            _fab.post(f"{self._base()}/getDefinition?format=TMDL", self._token, payload={}),
+            self._token,
+        )
+        definition = result.get("definition") if isinstance(result, dict) else None
+        parts = (definition or {}).get("parts", [])
+        if not parts:
+            raise ConnectionError(
+                f"Semantic model {self.item_id} returned no TMDL definition parts. "
+                "Confirm the workspace/dataset ids and that it is a semantic model."
+            )
+        _fab.decode_parts(parts, self._tmpdir)
+
+    def _push_definition(self) -> None:
+        parts = _fab.encode_parts(self._tmpdir)
+        _fab.poll_lro(
+            _fab.post(
+                f"{self._base()}/updateDefinition?updateMetadata=true",
+                self._token,
+                payload={"definition": {"parts": parts}},
+            ),
+            self._token,
+        )
+
+    # --- Writes: edit local TMDL, then push the whole definition back ---
+
+    def measure_add(self, table: str, name: str, expression: str, **kwargs: Any) -> dict[str, Any]:
+        record = super().measure_add(table, name, expression, **kwargs)
+        self._push_definition()
+        return record
+
+    def measure_update(self, table: str, name: str, **kwargs: Any) -> dict[str, Any]:
+        record = super().measure_update(table, name, **kwargs)
+        self._push_definition()
+        return record
+
+    def measure_delete(self, table: str, name: str) -> None:
+        super().measure_delete(table, name)
+        self._push_definition()
+
+    # --- Lifecycle ---
+
+    def disconnect(self) -> None:
+        self._connected = False
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def __del__(self) -> None:  # best-effort temp cleanup
+        try:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+        except Exception:
+            pass

--- a/src/pbi_cli/cli.py
+++ b/src/pbi_cli/cli.py
@@ -89,11 +89,24 @@ def _apply_dry_run(ctx: click.Context, param: click.Parameter, value: bool) -> b
 )
 @click.option(
     "--backend",
-    type=click.Choice(["desktop", "xmla", "mock", "file", "rest"]),
+    type=click.Choice(["desktop", "xmla", "mock", "file", "rest", "fabric"]),
     default="desktop",
     show_default=True,
     help="Backend: desktop (TOM), xmla (Premium/Fabric), mock (CI fixtures), "
-    "file (TMDL/PBIP folder — any OS), rest (executeQueries API — any OS).",
+    "file (TMDL/PBIP folder — any OS), rest (executeQueries API — any OS), "
+    "fabric (live model writes via Item Definition API — any OS).",
+)
+@click.option(
+    "--workspace",
+    "workspace_id",
+    default=None,
+    help="Fabric workspace id (fabric backend; or PBI_FABRIC_WORKSPACE).",
+)
+@click.option(
+    "--dataset",
+    "dataset_id",
+    default=None,
+    help="Fabric semantic-model id (fabric backend; or PBI_FABRIC_DATASET).",
 )
 @click.option(
     "--port",
@@ -116,6 +129,8 @@ def cli(  # noqa: PLR0913
     backend: str,
     port: int | None,
     model_path: str | None,
+    workspace_id: str | None,
+    dataset_id: str | None,
 ) -> None:
     """pbi — Power BI one-stop-shop CLI for AI-driven development.
 
@@ -131,6 +146,10 @@ def cli(  # noqa: PLR0913
         ctx.obj["port"] = port
     if model_path:
         ctx.obj["path"] = model_path
+    if workspace_id:
+        ctx.obj["workspace"] = workspace_id
+    if dataset_id:
+        ctx.obj["dataset"] = dataset_id
 
 
 # Register command groups

--- a/src/pbi_cli/commands/_shared.py
+++ b/src/pbi_cli/commands/_shared.py
@@ -43,6 +43,29 @@ def get_backend(ctx: click.Context) -> Any:
             except ConnectionError as exc:
                 console.print(f"[red]{exc}[/red]")
                 raise click.Abort()
+        elif backend_name == "fabric":
+            import os
+
+            from pbi_cli.backends.fabric_backend import FabricDefinitionBackend
+            from pbi_cli.fabric_api import FabricApiError
+
+            ws = obj.get("workspace") or os.environ.get("PBI_FABRIC_WORKSPACE")
+            ds = obj.get("dataset") or os.environ.get("PBI_FABRIC_DATASET")
+            if not (ws and ds):
+                console.print(
+                    "[red]The fabric backend needs a workspace and a semantic-model id.[/red]"
+                )
+                console.print(
+                    "Pass [bold]--workspace <id> --dataset <id>[/bold] "
+                    "(or set PBI_FABRIC_WORKSPACE / PBI_FABRIC_DATASET)."
+                )
+                raise click.Abort()
+            try:
+                b = FabricDefinitionBackend(ws, ds)
+                b.connect()
+            except (ConnectionError, FabricApiError, ValueError) as exc:
+                console.print(f"[red]{exc}[/red]")
+                raise click.Abort()
         elif backend_name == "xmla":
             b = XmlaBackend()
         else:

--- a/src/pbi_cli/fabric_api.py
+++ b/src/pbi_cli/fabric_api.py
@@ -161,6 +161,43 @@ def get_paged(url: str, token: str, value_key: str = "value") -> list[dict[str, 
     return items
 
 
+def encode_parts(folder: Any) -> list[dict[str, Any]]:
+    """Encode every file under *folder* as InlineBase64 item-definition parts.
+
+    Unlike the older command-level helper this keeps dotfiles (notably the
+    required ``.platform``) so a getDefinition → edit → updateDefinition round
+    trip stays faithful.
+    """
+    import base64
+    from pathlib import Path
+
+    folder = Path(folder)
+    parts: list[dict[str, Any]] = []
+    for f in sorted(folder.rglob("*")):
+        if f.is_file():
+            parts.append({
+                "path": f.relative_to(folder).as_posix(),
+                "payload": base64.b64encode(f.read_bytes()).decode(),
+                "payloadType": "InlineBase64",
+            })
+    return parts
+
+
+def decode_parts(parts: list[dict[str, Any]], folder: Any) -> list[str]:
+    """Write item-definition parts under *folder*, recreating the path tree."""
+    import base64
+    from pathlib import Path
+
+    folder = Path(folder)
+    written: list[str] = []
+    for part in parts:
+        target = folder / part["path"]
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(base64.b64decode(part["payload"]))
+        written.append(part["path"])
+    return written
+
+
 # Terminal states for a Fabric job instance.
 _JOB_TERMINAL = {"Completed", "Succeeded", "Failed", "Cancelled", "Deduped"}
 

--- a/tests/unit/test_fabric_backend.py
+++ b/tests/unit/test_fabric_backend.py
@@ -1,0 +1,135 @@
+"""Tests for the FabricDefinitionBackend (live model writes via Item Definition API)."""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from pbi_cli.cli import cli
+
+MODEL_TMDL = "model Model\n\tculture: en-US\n"
+SALES_TMDL = (
+    "table Sales\n"
+    "\n"
+    "\tcolumn Amount\n"
+    "\t\tdataType: double\n"
+    "\n"
+    "\tmeasure Revenue = SUM(Sales[Amount])\n"
+    "\t\tformatString: 0.00\n"
+)
+
+
+def _part(path: str, text: str) -> dict:
+    return {
+        "path": path,
+        "payload": base64.b64encode(text.encode()).decode(),
+        "payloadType": "InlineBase64",
+    }
+
+
+def _definition() -> dict:
+    return {"definition": {"parts": [
+        _part("definition/model.tmdl", MODEL_TMDL),
+        _part("definition/tables/Sales.tmdl", SALES_TMDL),
+        _part(".platform", '{"metadata": {"type": "SemanticModel"}}'),
+    ]}}
+
+
+def _mock_rest(push_result: dict | None = None):
+    """Patch fabric_api so getDefinition returns our TMDL and updateDefinition is captured."""
+    token = patch("pbi_cli.fabric_api.get_token", return_value="tok")
+    post = patch("pbi_cli.fabric_api.post", return_value={"status": 202, "headers": {}})
+
+    def _poll(resp, tok, **kw):
+        # First call (download) gets the definition; later calls (push) succeed.
+        _poll.calls += 1
+        return _definition() if _poll.calls == 1 else (push_result or {"status": "Succeeded"})
+
+    _poll.calls = 0
+    poll = patch("pbi_cli.fabric_api.poll_lro", side_effect=_poll)
+    return token, post, poll
+
+
+def _make_backend():
+    from pbi_cli.backends.fabric_backend import FabricDefinitionBackend
+
+    return FabricDefinitionBackend("ws-1", "ds-1")
+
+
+class TestDownloadAndRead:
+    def test_reads_measures_from_downloaded_tmdl(self):
+        token, post, poll = _mock_rest()
+        with token, post, poll:
+            b = _make_backend()
+            measures = b.measure_list()
+            b.disconnect()
+        assert any(m["name"] == "Revenue" for m in measures)
+
+    def test_no_parts_raises_connection_error(self):
+        with patch("pbi_cli.fabric_api.get_token", return_value="tok"), \
+                patch("pbi_cli.fabric_api.post", return_value={}), \
+                patch("pbi_cli.fabric_api.poll_lro", return_value={"definition": {"parts": []}}):
+            with pytest.raises(ConnectionError, match="no TMDL definition"):
+                _make_backend()
+
+
+class TestWritesPushDefinition:
+    def _pushed_parts(self, post_mock):
+        for call in post_mock.call_args_list:
+            url = call.args[0]
+            if "updateDefinition" in url:
+                return call.kwargs["payload"]["definition"]["parts"]
+        return None
+
+    def test_measure_add_pushes_updated_definition(self):
+        token, post, poll = _mock_rest()
+        with token, post as post_mock, poll:
+            b = _make_backend()
+            b.measure_add("Sales", "Margin", "DIVIDE([Revenue], 100)")
+            parts = self._pushed_parts(post_mock)
+            b.disconnect()
+        assert parts is not None, "updateDefinition was not called"
+        sales = next(p for p in parts if p["path"].endswith("tables/Sales.tmdl"))
+        decoded = base64.b64decode(sales["payload"]).decode()
+        assert "Margin" in decoded
+        # .platform round-trips (not dropped as a dotfile)
+        assert any(p["path"] == ".platform" for p in parts)
+
+    def test_measure_delete_pushes(self):
+        token, post, poll = _mock_rest()
+        with token, post as post_mock, poll:
+            b = _make_backend()
+            b.measure_delete("Sales", "Revenue")
+            urls = [c.args[0] for c in post_mock.call_args_list]
+            b.disconnect()
+        assert any("updateDefinition" in u for u in urls)
+
+
+class TestDisconnectCleansUp:
+    def test_disconnect_removes_tmpdir(self):
+        token, post, poll = _mock_rest()
+        with token, post, poll:
+            b = _make_backend()
+            tmp = b._tmpdir
+            assert tmp.exists()
+            b.disconnect()
+        assert not tmp.exists()
+
+
+class TestCliWiring:
+    def test_missing_ids_errors(self):
+        result = CliRunner().invoke(cli, ["--backend", "fabric", "measure", "list"])
+        assert result.exit_code != 0
+        assert "needs a workspace" in result.output
+
+    def test_measure_list_through_cli(self):
+        token, post, poll = _mock_rest()
+        with token, post, poll:
+            result = CliRunner().invoke(
+                cli, ["--backend", "fabric", "--workspace", "ws", "--dataset", "ds",
+                      "measure", "list"])
+        assert result.exit_code == 0
+        assert "Revenue" in result.output


### PR DESCRIPTION
**Phase 3** of the data-engineering roadmap: removes the last hard Windows dependency for the common case — editing measures on a *published* model.

## What
- **`--backend fabric`** writes measures to a live Fabric semantic model with no Windows and no XMLA: `pbi --backend fabric --workspace <ws> --dataset <ds> measure add/update/delete …`.
- It downloads the model's TMDL definition (`getDefinition`), edits it with the existing pure-Python TMDL writer, and pushes it back via `updateDefinition` (LRO). Closes the write gap the read-only `rest` backend left.
- `backends/fabric_backend.py` **subclasses `FileBackend`**, so all read/edit logic is reused — the backend is thin REST round-trip glue.
- `fabric_api.encode_parts`/`decode_parts`: faithful definition round-trip preserving the required `.platform` file (the older command-level helper dropped dotfiles).
- New global `--workspace` / `--dataset` flags (or `PBI_FABRIC_WORKSPACE` / `PBI_FABRIC_DATASET`).
- Scope: measures only; structural edits (tables, relationships, partitions) still use `desktop`/`xmla`.

## Verification
- **934 tests pass** (7 new backend tests, all with mocked REST so they run in CI), coverage **80.3%**, ruff + mypy clean.
- Full suite re-run against **Click 8.4.1 (latest)** — green, confirming no repeat of the 8.2 `mix_stderr` regression.

## Caveats
- `getDefinition`/`updateDefinition` + `?format=TMDL` are coded to current Fabric docs but **unverified against a live tenant** — worth a smoke test before release.
- Each write pushes the whole definition (atomic, not batched) — fine for interactive edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)