### PR TITLE
feat: PBIR batches 2-3, project scaffold, file-backend fail-loud + TMDL ref helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,79 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed — file backend: structural writes fail loud; shared `ref table` helper
+- `FileBackend` no longer silently no-ops structural writes it can't persist. Only
+  measure edits are written back to TMDL; `table_add`/`table_delete`, `column_add`/
+  `column_delete`, `relationship_add`, `hierarchy_*`, `calc_group_add`, `calc_item_*`,
+  `role_*`, and `partition_*` now raise `NotImplementedError` pointing at the
+  desktop/xmla backends or `pbi project new`. Previously they mutated only in-memory
+  state (lost at process exit) while the command reported success — e.g.
+  `--backend file source scaffold` printed "Scaffolded N tables" and wrote nothing.
+  The `fabric` backend inherits this until structural push-back is implemented.
+- New `tmdl_util` with idempotent `ensure_ref_table` / `remove_ref_table` /
+  `ensure_ref_culture` / `quote_tmdl_name`. TMDL does not auto-discover table files:
+  `model.tmdl` must carry a `ref table <name>` line per table or Desktop loads it
+  silently missing. `project_scaffold` now uses these helpers (output unchanged), and
+  any future table writer should keep the references in sync through them.
+
+### Added — PBIR report layer (batch 3): visual groups + mobile layout
+- `pbi visual group` — group existing visuals so they move/resize/format together
+  (`--member` repeatable, `--name` for the group label). Writes a group-container
+  `visual.json` with `visualGroup` + a computed bounding box, and tags each member
+  with `parentGroupName`. Format reverse-engineered from and verified live in
+  Desktop (clicking a member selects the whole group).
+- `pbi visual mobile` — place a visual on the phone layout canvas (320 wide),
+  writing a sibling `mobile.json` (`visualContainerMobileState`). Format captured
+  from Desktop's auto-create; verified to open and render in the mobile view.
+- `pbi visual list` now labels group containers as `group`.
+
+### Added — PBIR report layer (batch 2): icons, field rebinding, project scaffold, report measures, elements, bookmark groups
+- `pbi visual format --type icons` — icon-set conditional formatting. With no
+  `--rule`, reproduces Desktop's default 3-band percent icon set (CircleHigh /
+  SignMedium / SignLow over the field's min..max via RangePercent); with `--rule`,
+  absolute-threshold icons (first match wins). Format reverse-engineered from and
+  verified byte-for-byte against Power BI Desktop output, and confirmed rendering
+  live in Desktop.
+- `pbi visual format --type rules` now supports **between-bounds** rules:
+  `--rule "between:LOW:HIGH:#HEX"` (compiled to an `And` of two comparisons).
+- `pbi visual set-field` — rebind which field a visual role uses (rewrites the
+  query projection); `--append` to add rather than replace. The mass-edit verb.
+- `pbi project new` — scaffold a **complete, openable PBIP from scratch**: an
+  offline import semantic model (entered data via M `#table`, no data source) plus
+  a starter report. Emits the `ref table` / `ref cultureInfo` lines Desktop
+  requires. Verified to open and render in Desktop.
+- `pbi visual add-element` — add non-data elements: `textbox` (with text),
+  `button` (action button), `page-nav`, `bookmark-nav`. Shapes verified against
+  Desktop output; textbox/page-nav confirmed rendering live.
+- `pbi report measure-add` / `measure-list` — report-level measures in
+  `reportExtensions.json`. Each measure carries the schema-required `dataType`
+  (`--data-type`, default Double). Intended for live-connection reports; with a
+  byPath full-edit model, add measures to the model instead.
+- `pbi report bookmark-group-add` — group existing bookmarks under a named group
+  in `bookmarks.json`.
+
+### Added — PBIR report layer: visual update, rule/font conditional formatting, bookmark capture, interactions & slicer sync
+- `pbi visual update` — patch an existing visual's position (`--x/--y/--z/--width/--height/--tab-order`)
+  and `--title` in place, preserving query bindings and formatting. Closes the missing
+  CRUD verb (previously only add/delete existed). Works on PBIR GA and legacy report.json.
+- `pbi visual format --type rules` — rule-based (range) conditional formatting via a
+  `Conditional/Cases` expression, with `--rule OP:THRESHOLD:#HEX` (repeatable, first match
+  wins) and `--target fill|text` to colour the cell (`backColor`) or text (`fontColor`).
+  backColor + fontColor merge into a single Desktop-style `values` entry per field.
+- `pbi report bookmark-add` now **captures the page's visuals** into
+  `explorationState.sections` by default (previously wrote an empty skeleton that Desktop
+  stripped). `--hidden-visual <name>` (repeatable) records visuals with `display.mode=hidden`
+  for show/hide storytelling bookmarks; `--no-capture` keeps the old skeleton behaviour.
+- `pbi visual interaction` — set page-level cross-filtering between two visuals
+  (`--type Default|DataFilter|HighlightFilter|NoFilter`), written to `page.json`
+  `visualInteractions`.
+- `pbi visual sync-slicer` — add a slicer to a named `syncGroup` (`--group`, with
+  `--no-field-changes` / `--no-filter-changes`) so slicers stay synchronised across pages.
+- All shapes verified against Microsoft's published PBIR JSON schemas
+  (github.com/microsoft/json-schemas, page/bookmark 2.1.0). Icon-set conditional
+  formatting was intentionally deferred pending a Desktop-generated sample to verify its
+  byte format (a wrong shape is a blocking error that prevents the report from opening).
+
 ### Added — `fabric` backend: edit a live semantic model from any OS
 - New `--backend fabric` writes measures to a **published** Fabric semantic model
   without Windows or XMLA. It downloads the model's TMDL definition (getDefinition),

--- a/scripts/make_demo_pbip.py
+++ b/scripts/make_demo_pbip.py
@@ -1,0 +1,281 @@
+"""Generate a self-contained PBIR demo project that opens in Power BI Desktop.
+
+Produces a .pbip with:
+  - an offline import semantic model (entered data via M #table, no data source)
+  - a PBIR report exercising the new report-layer features:
+      visual update, rule-based + font conditional formatting, color scale,
+      visual interactions, slicer sync, and a state-capturing bookmark.
+
+Run:  python scripts/make_demo_pbip.py "<output folder>"
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from pathlib import Path
+
+from pbi_cli.backends.pbir_backend import PbirBackend
+from pbi_cli.intelligence.visual_builder import (
+    AGG_SUM,
+    FieldDef,
+    VisualSpec,
+    build_bar_chart,
+    build_card,
+    build_line_chart,
+    build_slicer,
+    build_table,
+)
+
+NAME = "Sales Demo"
+TABLE = "Financials"
+
+
+def _platform(item_type: str, display: str) -> str:
+    return json.dumps(
+        {
+            "$schema": "https://developer.microsoft.com/json-schemas/fabric/"
+            "gitIntegration/platformProperties/2.0.0/schema.json",
+            "metadata": {"type": item_type, "displayName": display},
+            "config": {"version": "2.0", "logicalId": str(uuid.uuid4())},
+        },
+        indent=2,
+    )
+
+
+def _data_rows() -> list[list]:
+    countries = ["USA", "Canada", "France", "Germany"]
+    segments = {"USA": "Enterprise", "Canada": "Midmarket", "France": "Government", "Germany": "Channel"}
+    months = ["01-Jan", "02-Feb", "03-Mar", "04-Apr", "05-May", "06-Jun",
+              "07-Jul", "08-Aug", "09-Sep", "10-Oct", "11-Nov", "12-Dec"]
+    rows: list[list] = []
+    for y, year in enumerate(["2023", "2024"]):
+        for c, country in enumerate(countries):
+            for m, month in enumerate(months):
+                base = 4000 + c * 1500 + m * 350 + y * 2000
+                sales = base + ((m * 7 + c * 13) % 9) * 220
+                cogs = round(sales * (0.55 + 0.03 * c), 0)
+                profit = round(sales - cogs, 0)
+                units = 80 + c * 20 + m * 5 + y * 30
+                rows.append([country, segments[country], year, month,
+                             float(sales), float(profit), int(units), float(cogs)])
+    return rows
+
+
+def _m_table(rows: list[list]) -> str:
+    def lit(v) -> str:
+        return f'"{v}"' if isinstance(v, str) else (str(int(v)) if isinstance(v, int) else str(v))
+
+    row_lines = ",\n\t\t\t\t\t".join(
+        "{" + ", ".join(lit(v) for v in r) + "}" for r in rows
+    )
+    return (
+        "let\n"
+        "\t\t\t\tSource = #table(\n"
+        "\t\t\t\t\ttype table [Country = text, Segment = text, Year = text, Month = text, "
+        'Sales = number, Profit = number, #"Units Sold" = Int64.Type, COGS = number],\n'
+        "\t\t\t\t\t{\n\t\t\t\t\t" + row_lines + "\n\t\t\t\t\t}\n"
+        "\t\t\t\t)\n"
+        "\t\t\tin\n"
+        "\t\t\t\tSource"
+    )
+
+
+def write_model(root: Path) -> None:
+    sm = root / f"{NAME}.SemanticModel"
+    (sm / "definition" / "tables").mkdir(parents=True, exist_ok=True)
+    (sm / ".platform").write_text(_platform("SemanticModel", NAME), encoding="utf-8")
+    (sm / "definition.pbism").write_text(
+        json.dumps(
+            {
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/"
+                "item/semanticModel/definitionProperties/1.0.0/schema.json",
+                "version": "4.2",
+                "settings": {},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (sm / "definition" / "database.tmdl").write_text(
+        "database\n\tcompatibilityLevel: 1550\n", encoding="utf-8"
+    )
+    # NOTE: TMDL does NOT auto-discover tables — model.tmdl must explicitly
+    # `ref table <name>` every table file, and `ref cultureInfo` every culture.
+    (sm / "definition" / "model.tmdl").write_text(
+        "model Model\n"
+        "\tculture: en-US\n"
+        "\tdefaultPowerBIDataSourceVersion: powerBI_V3\n"
+        "\tdiscourageImplicitMeasures\n"
+        "\tsourceQueryCulture: en-US\n"
+        "\tdataAccessOptions\n"
+        "\t\tlegacyRedirects\n"
+        "\t\treturnErrorValuesAsNull\n\n"
+        '\tannotation PBI_QueryOrder = ["Financials"]\n\n'
+        '\tannotation PBI_ProTooling = ["DevMode"]\n\n'
+        "ref table Financials\n\n"
+        "ref cultureInfo en-US\n",
+        encoding="utf-8",
+    )
+    (sm / "definition" / "cultures").mkdir(parents=True, exist_ok=True)
+    (sm / "definition" / "cultures" / "en-US.tmdl").write_text(
+        "cultureInfo en-US\n", encoding="utf-8"
+    )
+
+    rows = _data_rows()
+    cols = [
+        ("Country", "string", "none"),
+        ("Segment", "string", "none"),
+        ("Year", "string", "none"),
+        ("Month", "string", "none"),
+        ("Sales", "double", "sum"),
+        ("Profit", "double", "sum"),
+        ("Units Sold", "int64", "sum"),
+        ("COGS", "double", "sum"),
+    ]
+    parts = ["table Financials\n"]
+    for cname, dtype, summ in cols:
+        obj = f"'{cname}'" if " " in cname else cname
+        parts.append(
+            f"\n\tcolumn {obj}\n"
+            f"\t\tdataType: {dtype}\n"
+            f"\t\tsummarizeBy: {summ}\n"
+            f"\t\tsourceColumn: {cname}\n"
+        )
+    parts.append(
+        "\n\tmeasure 'Profit Margin %' = DIVIDE(SUM(Financials[Profit]), SUM(Financials[Sales]))\n"
+        "\t\tformatString: 0.0%\n"
+    )
+    parts.append(
+        "\n\tpartition Financials = m\n"
+        "\t\tmode: import\n"
+        "\t\tsource =\n"
+        "\t\t\t" + _m_table(rows) + "\n"
+    )
+    (sm / "definition" / "tables" / "Financials.tmdl").write_text(
+        "".join(parts), encoding="utf-8"
+    )
+
+
+def write_report(root: Path) -> PbirBackend:
+    rep = root / f"{NAME}.Report"
+    rep.mkdir(parents=True, exist_ok=True)
+    (rep / ".platform").write_text(_platform("Report", NAME), encoding="utf-8")
+    (rep / "definition.pbir").write_text(
+        json.dumps(
+            {
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/"
+                "item/report/definitionProperties/2.0.0/schema.json",
+                "version": "4.0",
+                "datasetReference": {"byPath": {"path": f"../{NAME}.SemanticModel"}},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    # Backend creates definition/ + report.json (PBIR GA) on load.
+    b = PbirBackend(str(root))
+    (rep / "definition" / "version.json").write_text(
+        json.dumps(
+            {
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/"
+                "item/report/definition/versionMetadata/1.0.0/schema.json",
+                "version": "2.0.0",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return b
+
+
+def col(prop: str) -> FieldDef:
+    return FieldDef(entity=TABLE, property=prop, is_measure=False, agg=None)
+
+
+def agg(prop: str) -> FieldDef:
+    return FieldDef(entity=TABLE, property=prop, agg=AGG_SUM)
+
+
+def build(b: PbirBackend) -> None:
+    PAGE = "Overview"
+    b.page_add(PAGE)
+    G = 16
+    names: dict[str, str] = {}
+
+    # Row 1 — KPI cards
+    for i, (prop, title) in enumerate(
+        [("Sales", "Total Sales"), ("Profit", "Total Profit"), ("Units Sold", "Units Sold")]
+    ):
+        info = b.visual_add(
+            PAGE,
+            VisualSpec("card", build_card(agg(prop)), x=G + i * 296, y=G,
+                       width=280, height=120, title=title),
+        )
+        names[prop] = info["name"]
+
+    # Row 2 — bar (Sales by Country), slicer (Year), line (Sales by Month)
+    y2 = 152
+    bar = b.visual_add(
+        PAGE, VisualSpec("barChart", build_bar_chart(col("Country"), agg("Sales")),
+                         x=G, y=y2, width=560, height=320, title="Sales by Country"))
+    slicer = b.visual_add(
+        PAGE, VisualSpec("slicer", build_slicer(col("Year")),
+                         x=592, y=y2, width=180, height=320, title="Year"))
+    line = b.visual_add(
+        PAGE, VisualSpec("lineChart", build_line_chart(col("Month"), agg("Sales")),
+                         x=788, y=y2, width=476, height=320, title="Sales by Month"))
+
+    # Row 3 — detail table
+    table = b.visual_add(
+        PAGE, VisualSpec("tableEx",
+                         build_table([col("Country"), agg("Sales"), agg("Profit")]),
+                         x=G, y=488, width=1248, height=216, title="Detail"))
+
+    # ── Exercise the new features ──────────────────────────────────────────────
+    # 1) visual update — reposition + retitle the Units card
+    b.visual_update(PAGE, names["Units Sold"], width=280, title="Units Sold (YTD)")
+
+    # 2) color scale on Sales + rule-based font colour on Profit (red if negative)
+    b.visual_format_color_scale(PAGE, table["name"], TABLE, "Sales",
+                                low_color="#FFF3B0", high_color="#2A9D8F", mid_color=None)
+    b.visual_format_rules(PAGE, table["name"], TABLE, "Profit",
+                          [(">=", 0, "#107C10"), ("<", 0, "#A4262C")], target="fontColor")
+
+    # 3) interaction — Year slicer should NOT filter the Total Sales card
+    b.set_visual_interaction(PAGE, slicer["name"], names["Sales"], "NoFilter")
+
+    # 4) slicer sync group
+    b.set_slicer_sync(PAGE, slicer["name"], "YearSync")
+
+    # 5) bookmarks — full view, and a "focus" view with the bar chart hidden
+    b.bookmark_add("Full View", page=PAGE)
+    b.bookmark_add("Focus: hide bar", page=PAGE, hidden_visuals=[bar["name"]])
+
+
+def main() -> None:
+    out = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.home() / "Documents" / "pbi-cli-demo"
+    root = out / NAME
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"{NAME}.pbip").write_text(
+        json.dumps(
+            {
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/"
+                "pbip/pbipProperties/1.0.0/schema.json",
+                "version": "1.0",
+                "artifacts": [{"report": {"path": f"{NAME}.Report"}}],
+                "settings": {"enableAutoRecovery": True},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    write_model(root)
+    b = write_report(root)
+    build(b)
+    print(f"Created PBIP at: {root / (NAME + '.pbip')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pbi_cli/backends/file_backend.py
+++ b/src/pbi_cli/backends/file_backend.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 from pbi_cli.backends.mock_backend import MockTomBackend
 
@@ -503,6 +503,70 @@ class FileBackend(MockTomBackend):
             start, end = span
             del lines[start:end]
             tf.write_text("".join(lines), encoding="utf-8")
+
+    # --- Structural writes are not persisted (fail loud, never silently no-op) ---
+    #
+    # Only measure edits are written back to TMDL. Table / column / relationship /
+    # hierarchy / calc-group / role / partition writes would otherwise mutate just
+    # the in-memory state — which dies at process exit — while the command reports
+    # success. That silent data loss is worse than an error, so these raise.
+    # (When real TMDL persistence lands, these get replaced one method at a time.)
+
+    def _unpersisted(self, op: str) -> NoReturn:
+        raise NotImplementedError(
+            f"The file backend cannot persist {op} — only measure edits are written "
+            "back to TMDL. Use --backend desktop or xmla for live structural edits, "
+            "or `pbi project new` to scaffold a model from scratch."
+        )
+
+    def table_add(self, name: str, **kwargs: Any) -> dict[str, Any]:
+        self._unpersisted("table creation")
+
+    def table_delete(self, name: str) -> None:
+        self._unpersisted("table deletion")
+
+    def column_add(self, table: str, name: str, data_type: str, **kwargs: Any) -> dict[str, Any]:
+        self._unpersisted("column creation")
+
+    def column_delete(self, table: str, name: str) -> None:
+        self._unpersisted("column deletion")
+
+    def relationship_add(
+        self, from_table: str, from_column: str, to_table: str, to_column: str, **kwargs: Any
+    ) -> dict[str, Any]:
+        self._unpersisted("relationship creation")
+
+    def hierarchy_add(self, table: str, name: str, levels: list[dict[str, Any]]) -> dict[str, Any]:
+        self._unpersisted("hierarchy creation")
+
+    def hierarchy_delete(self, table: str, name: str) -> None:
+        self._unpersisted("hierarchy deletion")
+
+    def calc_group_add(self, name: str, precedence: int = 0) -> dict[str, Any]:
+        self._unpersisted("calculation-group creation")
+
+    def calc_item_add(
+        self, group_table: str, name: str, expression: str, ordinal: int = 0
+    ) -> dict[str, Any]:
+        self._unpersisted("calculation-item creation")
+
+    def calc_item_delete(self, group_table: str, name: str) -> None:
+        self._unpersisted("calculation-item deletion")
+
+    def role_add(self, name: str, table: str, filter_expression: str) -> dict[str, Any]:
+        self._unpersisted("role creation")
+
+    def role_delete(self, name: str) -> None:
+        self._unpersisted("role deletion")
+
+    def partition_add(self, table: str, name: str, query: str) -> dict[str, Any]:
+        self._unpersisted("partition creation")
+
+    def partition_delete(self, table: str, name: str) -> None:
+        self._unpersisted("partition deletion")
+
+    def partition_refresh(self, table: str, name: str) -> dict[str, Any]:
+        self._unpersisted("partition refresh")
 
     # --- Not supported without a live engine ---
 

--- a/src/pbi_cli/backends/pbir_backend.py
+++ b/src/pbi_cli/backends/pbir_backend.py
@@ -266,10 +266,14 @@ class PbirBackend:
                 continue
             data = json.loads(vj.read_text(encoding="utf-8"))
             pos = data.get("position", {})
+            # Group containers have a `visualGroup` block instead of `visual`.
+            vtype = data.get("visual", {}).get("visualType", "")
+            if not vtype and "visualGroup" in data:
+                vtype = "group"
             results.append(
                 {
                     "name": data.get("name", vdir.name),
-                    "visualType": data.get("visual", {}).get("visualType", ""),
+                    "visualType": vtype,
                     "x": pos.get("x", 0),
                     "y": pos.get("y", 0),
                     "width": pos.get("width", 0),
@@ -488,25 +492,52 @@ class PbirBackend:
         result += [v for k, v in by_id.items() if k not in ordered_ids]
         return result
 
-    def bookmark_add(self, display_name: str, page: str | None = None) -> dict[str, Any]:
+    def bookmark_add(
+        self,
+        display_name: str,
+        page: str | None = None,
+        hidden_visuals: list[str] | None = None,
+        capture: bool = True,
+    ) -> dict[str, Any]:
         """Add a named bookmark as a flat {id}.bookmark.json file.
 
-        Desktop format: schema 2.1.0, explorationState version "1.3",
-        options.targetVisualNames: [].
+        Desktop format: schema 2.1.0, explorationState version "1.3".
+
+        When ``capture`` is True (default), the bookmark records the actual
+        visuals on the target page into ``explorationState.sections`` so the
+        bookmark is not stripped when reopened in Desktop. Any visual name in
+        ``hidden_visuals`` is recorded with ``display.mode = "hidden"`` —
+        the standard way to build show/hide (storytelling) bookmarks.
         """
         self._require_load()
         bm_id = uuid.uuid4().hex[:20]  # Desktop uses 20-char hex ids
+        hidden = set(hidden_visuals or [])
 
-        # Resolve active page GUID
+        # Resolve active page GUID + its display name for capture
         active_section = ""
+        active_display = page
+        pages = self.page_list()
         if page:
-            page_info = next((p for p in self.page_list() if p["displayName"] == page), None)
+            page_info = next((p for p in pages if p["displayName"] == page), None)
             if page_info:
                 active_section = page_info["name"]
-        else:
-            pages = self.page_list()
-            if pages:
-                active_section = pages[0]["name"]
+        elif pages:
+            active_section = pages[0]["name"]
+            active_display = pages[0]["displayName"]
+
+        sections: dict[str, Any] = {}
+        target_visuals: list[str] = []
+        if capture and active_section and active_display:
+            visual_containers: dict[str, Any] = {}
+            for v in self.visual_list(active_display):
+                vname = v["name"]
+                single_visual: dict[str, Any] = {"visualType": v["visualType"]}
+                if vname in hidden:
+                    single_visual["display"] = {"mode": "hidden"}
+                visual_containers[vname] = {"singleVisual": single_visual}
+                target_visuals.append(vname)
+            if visual_containers:
+                sections[active_section] = {"visualContainers": visual_containers}
 
         bm: dict[str, Any] = {
             "$schema": (
@@ -515,11 +546,11 @@ class PbirBackend:
             ),
             "displayName": display_name,
             "name": bm_id,
-            "options": {"targetVisualNames": []},
+            "options": {"targetVisualNames": target_visuals},
             "explorationState": {
                 "version": "1.3",
                 "activeSection": active_section,
-                "sections": {},
+                "sections": sections,
             },
         }
 
@@ -533,7 +564,13 @@ class PbirBackend:
         meta["items"] = items
         self._ga_write_bookmarks_json(meta)
 
-        return {"name": bm_id, "displayName": display_name, "page": active_section}
+        return {
+            "name": bm_id,
+            "displayName": display_name,
+            "page": active_section,
+            "options": {"targetVisualNames": target_visuals},
+            "hiddenCount": len(hidden & set(target_visuals)),
+        }
 
     def bookmark_delete(self, display_name: str) -> bool:
         """Delete a bookmark by display name. Returns True if found and deleted."""
@@ -796,6 +833,704 @@ class PbirBackend:
             }
         )
         vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return True
+
+    # ── Visual update / patch ──────────────────────────────────────────────────
+
+    def visual_update(
+        self,
+        page: str,
+        visual_name: str,
+        *,
+        x: int | None = None,
+        y: int | None = None,
+        z: int | None = None,
+        width: int | None = None,
+        height: int | None = None,
+        tab_order: int | None = None,
+        title: str | None = None,
+    ) -> bool:
+        """Patch an existing visual's position and/or title in place.
+
+        Only the supplied arguments are changed; everything else (query
+        bindings, formatting) is preserved. Returns True if the visual was
+        found and updated. To rebind fields, delete + re-add the visual.
+        """
+        self._require_load()
+        if self._format == "pbir_ga":
+            return self._ga_visual_update(
+                page, visual_name, x, y, z, width, height, tab_order, title
+            )
+        return self._old_visual_update(
+            page, visual_name, x, y, z, width, height, tab_order, title
+        )
+
+    @staticmethod
+    def _title_object(title: str) -> list[dict[str, Any]]:
+        return [
+            {
+                "properties": {
+                    "show": {"expr": {"Literal": {"Value": "true"}}},
+                    "text": {"expr": {"Literal": {"Value": f"'{title}'"}}},
+                }
+            }
+        ]
+
+    def _ga_visual_update(
+        self,
+        page: str,
+        visual_name: str,
+        x: int | None,
+        y: int | None,
+        z: int | None,
+        width: int | None,
+        height: int | None,
+        tab_order: int | None,
+        title: str | None,
+    ) -> bool:
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return False
+        vj, data = found
+        pos = data.setdefault("position", {})
+        for key, value in (
+            ("x", x),
+            ("y", y),
+            ("z", z),
+            ("width", width),
+            ("height", height),
+            ("tabOrder", tab_order),
+        ):
+            if value is not None:
+                pos[key] = value
+        if title is not None:
+            vco = data.setdefault("visual", {}).setdefault("visualContainerObjects", {})
+            vco["title"] = self._title_object(title)
+        vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return True
+
+    def _old_visual_update(
+        self,
+        page: str,
+        visual_name: str,
+        x: int | None,
+        y: int | None,
+        z: int | None,
+        width: int | None,
+        height: int | None,
+        tab_order: int | None,
+        title: str | None,
+    ) -> bool:
+        section = self._old_find_section(page)
+        if not section:
+            return False
+        for vc in section.get("visualContainers", []):
+            try:
+                cfg = json.loads(vc.get("config", "{}"))
+            except Exception:
+                continue
+            if cfg.get("name") != visual_name:
+                continue
+            updates = {
+                "x": x,
+                "y": y,
+                "z": z,
+                "width": width,
+                "height": height,
+                "tabOrder": tab_order,
+            }
+            for key, value in updates.items():
+                if value is None:
+                    continue
+                vc[key] = value
+                for layout in cfg.get("layouts", []):
+                    layout.setdefault("position", {})[key] = value
+            if title is not None:
+                sv = cfg.setdefault("singleVisual", {})
+                sv.setdefault("objects", {})["title"] = self._title_object(title)
+            vc["config"] = json.dumps(cfg, separators=(",", ":"))
+            self._save_old()
+            return True
+        return False
+
+    # ── Conditional formatting: rule-based (range) + font color ─────────────────
+    # Rule-based colouring uses a Conditional/Cases expression. Cases evaluate
+    # top-to-bottom and the first matching case wins, so order your rules from
+    # most specific (highest threshold) to least.
+
+    COMPARISON_KIND = {">": 1, ">=": 2, "<": 3, "<=": 4, "=": 0, "==": 0}
+
+    @staticmethod
+    def _num_literal(value: float | int) -> str:
+        """Power BI numeric literal — double suffix 'D' (e.g. 50000 -> '50000D')."""
+        if isinstance(value, float) and value.is_integer():
+            value = int(value)
+        return f"{value}D"
+
+    @classmethod
+    def _comparison(cls, left: dict[str, Any], op: str, threshold: float) -> dict[str, Any]:
+        if op not in cls.COMPARISON_KIND:
+            raise ValueError(f"unknown operator '{op}'; use one of {sorted(cls.COMPARISON_KIND)}")
+        return {
+            "Comparison": {
+                "ComparisonKind": cls.COMPARISON_KIND[op],
+                "Left": left,
+                "Right": {"Literal": {"Value": cls._num_literal(threshold)}},
+            }
+        }
+
+    @classmethod
+    def _rule_conditions(
+        cls, rules: list[tuple], left: dict[str, Any]
+    ) -> list[tuple[dict[str, Any], str]]:
+        """Turn (op, threshold, color) / ('between', low, high, color) rules into
+        (Condition, color) pairs. 'between' becomes an And of >= low and < high."""
+        out: list[tuple[dict[str, Any], str]] = []
+        for rule in rules:
+            if rule and rule[0] == "between":
+                _, low, high, color = rule
+                cond = {
+                    "And": {
+                        "Left": cls._comparison(left, ">=", low),
+                        "Right": cls._comparison(left, "<", high),
+                    }
+                }
+            else:
+                op, threshold, color = rule
+                cond = cls._comparison(left, op, threshold)
+            out.append((cond, color))
+        return out
+
+    @staticmethod
+    def _upsert_values_entry(
+        values_obj: list[dict[str, Any]],
+        selector: dict[str, Any],
+        query_ref: str,
+        properties: dict[str, Any],
+    ) -> None:
+        """Merge `properties` into the values entry for `query_ref`, or append one.
+
+        Desktop keeps a single entry per selector with multiple property keys,
+        so applying backColor then fontColor to the same field yields one entry.
+        """
+        for entry in values_obj:
+            if entry.get("selector", {}).get("metadata") == query_ref:
+                entry.setdefault("properties", {}).update(properties)
+                entry["selector"] = selector
+                return
+        values_obj.append({"selector": selector, "properties": properties})
+
+    def visual_format_rules(
+        self,
+        page: str,
+        visual_name: str,
+        table: str,
+        measure: str,
+        rules: list[tuple[str, float, str]],
+        target: str = "backColor",
+    ) -> bool:
+        """Apply rule-based (conditional) colour formatting to a table/matrix field.
+
+        rules: list of (operator, threshold, hex_color). operator is one of
+        ``> >= < <= =``. Cases are evaluated in the given order; first match wins.
+        target: ``backColor`` (cell fill) or ``fontColor`` (text colour).
+
+        Returns True if the visual was found and updated.
+        """
+        if target not in ("backColor", "fontColor"):
+            raise ValueError("target must be 'backColor' or 'fontColor'")
+        if not rules:
+            raise ValueError("at least one rule is required")
+
+        self._require_load()
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return False
+        vj, data = found
+
+        proj = self._find_projection(data, table, measure)
+        query_ref = proj[0] if proj else f"Sum({table}[{measure}])"
+        field_expr = (
+            proj[1]
+            if proj
+            else {
+                "Aggregation": {
+                    "Expression": {
+                        "Column": {
+                            "Expression": {"SourceRef": {"Entity": table}},
+                            "Property": measure,
+                        }
+                    },
+                    "Function": 0,
+                }
+            }
+        )
+
+        cases: list[dict[str, Any]] = [
+            {"Condition": cond, "Value": {"Literal": {"Value": f"'{color}'"}}}
+            for cond, color in self._rule_conditions(rules, field_expr)
+        ]
+
+        conditional_expr = {"Conditional": {"Cases": cases}}
+        selector: dict[str, Any] = {
+            "data": [{"dataViewWildcard": {"matchingOption": 1}}],
+            "metadata": query_ref,
+        }
+        properties = {target: {"solid": {"color": {"expr": conditional_expr}}}}
+
+        objects = data.setdefault("visual", {}).setdefault("objects", {})
+        values_obj = objects.setdefault("values", [])
+        self._upsert_values_entry(values_obj, selector, query_ref, properties)
+        vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return True
+
+    # ── Icon-set conditional formatting ────────────────────────────────────────
+    # Format reverse-engineered from Power BI Desktop output. Icons live under
+    # objects.values[].properties.icon as a Conditional/Cases over the field.
+    # Default (rules=None) reproduces Desktop's 3-band percent-of-range icon set;
+    # custom rules use absolute thresholds (first match wins).
+
+    @staticmethod
+    def _icon_select_ref(query_ref: str) -> dict[str, Any]:
+        return {"SelectRef": {"ExpressionName": query_ref}}
+
+    @staticmethod
+    def _icon_range_percent(query_ref: str, percent: float) -> dict[str, Any]:
+        """RangePercent node: percent of the field's min..max across all rows."""
+        def _scoped_minmax(func: int) -> dict[str, Any]:
+            # func 3 = Min, 4 = Max
+            return {
+                "ScopedEval": {
+                    "Expression": {
+                        "Aggregation": {
+                            "Expression": {
+                                "ScopedEval": {
+                                    "Expression": {
+                                        "SelectRef": {"ExpressionName": query_ref}
+                                    },
+                                    "Scope": [{"AllRolesRef": {}}],
+                                }
+                            },
+                            "Function": func,
+                        }
+                    },
+                    "Scope": [],
+                }
+            }
+
+        return {
+            "RangePercent": {
+                "Min": _scoped_minmax(3),
+                "Max": _scoped_minmax(4),
+                "Percent": percent,
+            }
+        }
+
+    def visual_format_icons(
+        self,
+        page: str,
+        visual_name: str,
+        table: str,
+        measure: str,
+        rules: list[tuple[str, float, str]] | None = None,
+        layout: str = "Before",
+    ) -> bool:
+        """Apply icon-set conditional formatting to a table/matrix field.
+
+        rules=None  → Desktop's default 3-band percent icon set
+                      (>=67% CircleHigh, 33-67% SignMedium, <33% SignLow).
+        rules       → list of (operator, threshold, icon_name); absolute
+                      thresholds, first match wins. icon_name is a Power BI icon
+                      id, e.g. 'CircleHigh', 'CircleMedium', 'CircleLow',
+                      'SignMedium', 'SignLow', 'ArrowUp', 'ArrowDown'.
+        layout: 'Before' | 'After' | 'IconOnly' — icon position vs the value.
+
+        Returns True if the visual was found and updated.
+        """
+        self._require_load()
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return False
+        vj, data = found
+
+        proj = self._find_projection(data, table, measure)
+        query_ref = proj[0] if proj else f"Sum({table}[{measure}])"
+        ref = self._icon_select_ref(query_ref)
+
+        if rules:
+            cases = [
+                {"Condition": cond, "Value": {"Literal": {"Value": f"'{icon}'"}}}
+                for cond, icon in self._rule_conditions(rules, ref)
+            ]
+        else:
+            cases = [
+                {
+                    "Condition": {"Comparison": {
+                        "ComparisonKind": 2, "Left": ref,
+                        "Right": self._icon_range_percent(query_ref, 0.67),
+                    }},
+                    "Value": {"Literal": {"Value": "'CircleHigh'"}},
+                },
+                {
+                    "Condition": {"And": {
+                        "Left": {"Comparison": {
+                            "ComparisonKind": 2, "Left": ref,
+                            "Right": self._icon_range_percent(query_ref, 0.33),
+                        }},
+                        "Right": {"Comparison": {
+                            "ComparisonKind": 3, "Left": ref,
+                            "Right": self._icon_range_percent(query_ref, 0.67),
+                        }},
+                    }},
+                    "Value": {"Literal": {"Value": "'SignMedium'"}},
+                },
+                {
+                    "Condition": {"Comparison": {
+                        "ComparisonKind": 3, "Left": ref,
+                        "Right": self._icon_range_percent(query_ref, 0.33),
+                    }},
+                    "Value": {"Literal": {"Value": "'SignLow'"}},
+                },
+            ]
+
+        icon_obj = {
+            "kind": "Icon",
+            "layout": {"expr": {"Literal": {"Value": f"'{layout}'"}}},
+            "verticalAlignment": {"expr": {"Literal": {"Value": "'Top'"}}},
+            "value": {"expr": {"Conditional": {"Cases": cases}}},
+        }
+        selector: dict[str, Any] = {
+            "data": [{"dataViewWildcard": {"matchingOption": 1}}],
+            "metadata": query_ref,
+        }
+        objects = data.setdefault("visual", {}).setdefault("objects", {})
+        values_obj = objects.setdefault("values", [])
+        self._upsert_values_entry(values_obj, selector, query_ref, {"icon": icon_obj})
+        vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return True
+
+    # ── Visual field rebinding ─────────────────────────────────────────────────
+
+    def visual_set_field(
+        self,
+        page: str,
+        visual_name: str,
+        role: str,
+        table: str,
+        field: str,
+        *,
+        is_measure: bool = False,
+        agg: int | None = 0,
+        replace: bool = True,
+    ) -> bool:
+        """Bind a field to a visual role slot, rewriting its query projection.
+
+        role: visual role name (Category, Y, Values, Rows, Columns, ...).
+        replace=True swaps the role's existing projections for this one field;
+        replace=False appends it. PBIR GA only. Returns True if found+updated.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Field rebinding requires PBIR GA format (definition/ folder).")
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return False
+        vj, data = found
+
+        from pbi_cli.intelligence.visual_builder import FieldDef
+
+        fd = FieldDef(entity=table, property=field, is_measure=is_measure, agg=agg)
+        projection = fd.to_projection()
+
+        query = data.setdefault("visual", {}).setdefault("query", {})
+        query_state = query.setdefault("queryState", {})
+        role_data = query_state.setdefault(role, {})
+        projections = role_data.setdefault("projections", [])
+        if replace:
+            projections.clear()
+            projections.append(projection)
+        else:
+            projections.append(projection)
+        vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return True
+
+    # ── Report-level measures (reportExtensions.json) ──────────────────────────
+
+    def _report_extension_path(self) -> Path:
+        assert self._report_dir
+        return self._report_dir / "definition" / "reportExtensions.json"
+
+    def report_measure_add(
+        self,
+        table: str,
+        name: str,
+        expression: str,
+        format_string: str | None = None,
+        data_type: str = "Double",
+    ) -> dict[str, Any]:
+        """Add (or replace) a report-level measure in reportExtensions.json.
+
+        Report-level measures live only in the report and target a table (entity)
+        in the connected semantic model. Per the reportExtension schema, each
+        measure requires name, expression and dataType (Text|Integer|Double|...).
+        Intended for live-connection reports; with a byPath (full-edit) model,
+        add measures to the model instead. PBIR GA only.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Report-level measures require PBIR GA format.")
+        path = self._report_extension_path()
+        if path.exists():
+            ext = json.loads(path.read_text(encoding="utf-8"))
+        else:
+            ext = {
+                "$schema": (
+                    "https://developer.microsoft.com/json-schemas/fabric/item/"
+                    "report/definition/reportExtension/1.0.0/schema.json"
+                ),
+                "name": "extension",
+                "entities": [],
+            }
+
+        # dataType is required by the reportExtension schema.
+        measure: dict[str, Any] = {
+            "name": name,
+            "dataType": data_type,
+            "expression": expression,
+        }
+        if format_string:
+            measure["formatString"] = format_string
+
+        entities: list[dict[str, Any]] = ext.setdefault("entities", [])
+        entity = next((e for e in entities if e.get("name") == table), None)
+        if entity is None:
+            entity = {"name": table, "measures": []}
+            entities.append(entity)
+        measures: list[dict[str, Any]] = entity.setdefault("measures", [])
+        measures[:] = [m for m in measures if m.get("name") != name]
+        measures.append(measure)
+
+        path.write_text(json.dumps(ext, indent=2), encoding="utf-8")
+        return {"table": table, "name": name}
+
+    def report_measure_list(self) -> list[dict[str, Any]]:
+        """List report-level measures defined in reportExtensions.json."""
+        self._require_load()
+        path = self._report_extension_path()
+        if not path.exists():
+            return []
+        ext = json.loads(path.read_text(encoding="utf-8"))
+        out: list[dict[str, Any]] = []
+        for entity in ext.get("entities", []):
+            for m in entity.get("measures", []):
+                out.append(
+                    {
+                        "table": entity.get("name", ""),
+                        "name": m.get("name", ""),
+                        "expression": m.get("expression", ""),
+                    }
+                )
+        return out
+
+    # ── Bookmark groups ────────────────────────────────────────────────────────
+
+    def bookmark_group_add(
+        self, display_name: str, member_display_names: list[str]
+    ) -> dict[str, Any]:
+        """Create a bookmark group containing the named bookmarks (PBIR GA).
+
+        Groups are recorded in bookmarks.json: a group item carries a nested
+        `children` list referencing member bookmark ids.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Bookmark groups require PBIR GA format.")
+
+        existing = {b["displayName"]: b["name"] for b in self.bookmark_list()}
+        member_ids = [existing[n] for n in member_display_names if n in existing]
+
+        meta = self._ga_read_bookmarks_json()
+        items: list[dict[str, Any]] = meta.get("items", [])
+        # Remove members from the top level — they move under the group.
+        member_set = set(member_ids)
+        items = [it for it in items if it.get("name") not in member_set]
+
+        group_id = uuid.uuid4().hex[:20]
+        items.append(
+            {
+                "name": group_id,
+                "displayName": display_name,
+                "children": [{"name": mid} for mid in member_ids],
+            }
+        )
+        meta["items"] = items
+        self._ga_write_bookmarks_json(meta)
+        return {"name": group_id, "displayName": display_name, "members": member_ids}
+
+    # ── Visual interactions (page level) ───────────────────────────────────────
+
+    INTERACTION_TYPES = ("Default", "DataFilter", "HighlightFilter", "NoFilter")
+
+    def set_visual_interaction(
+        self, page: str, source: str, target: str, interaction_type: str
+    ) -> None:
+        """Set how a source visual filters a target visual on a page.
+
+        interaction_type: Default | DataFilter | HighlightFilter | NoFilter.
+        Replaces any existing rule for the same source/target pair.
+        PBIR GA only.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Visual interactions require PBIR GA format (definition/ folder).")
+        if interaction_type not in self.INTERACTION_TYPES:
+            raise ValueError(f"type must be one of {self.INTERACTION_TYPES}")
+
+        page_dir = self._ga_find_page_dir(page)
+        if not page_dir:
+            raise ValueError(f"Page '{page}' not found.")
+        pj = page_dir / "page.json"
+        data = json.loads(pj.read_text(encoding="utf-8"))
+        interactions: list[dict[str, Any]] = data.setdefault("visualInteractions", [])
+        interactions[:] = [
+            i for i in interactions if not (i.get("source") == source and i.get("target") == target)
+        ]
+        interactions.append({"source": source, "target": target, "type": interaction_type})
+        pj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    # ── Slicer sync ────────────────────────────────────────────────────────────
+
+    def set_slicer_sync(
+        self,
+        page: str,
+        visual_name: str,
+        group_name: str,
+        field_changes: bool = True,
+        filter_changes: bool = True,
+    ) -> bool:
+        """Place a slicer visual into a named sync group.
+
+        Slicers sharing the same group_name stay synchronised. PBIR GA only.
+        Returns True if the visual was found and updated.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Slicer sync requires PBIR GA format (definition/ folder).")
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return False
+        vj, data = found
+        data.setdefault("visual", {})["syncGroup"] = {
+            "groupName": group_name,
+            "fieldChanges": field_changes,
+            "filterChanges": filter_changes,
+        }
+        vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return True
+
+    # ── Visual container groups ────────────────────────────────────────────────
+    # Verified against Desktop: a group is its own visual.json (no `visual` key)
+    # carrying `visualGroup: {displayName, groupMode}` and a bounding-box position;
+    # each member visual.json gets a top-level `parentGroupName` = the group id.
+
+    def visual_group_add(
+        self,
+        page: str,
+        member_names: list[str],
+        display_name: str | None = None,
+        group_mode: str = "ScaleMode",
+    ) -> dict[str, Any]:
+        """Group existing visuals on a page. Returns the group info.
+
+        Computes the group's bounding box from its members. PBIR GA only.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Visual groups require PBIR GA format (definition/ folder).")
+        from pbi_cli.intelligence.visual_builder import VISUAL_CONTAINER_SCHEMA
+
+        vd = self._ga_visuals_dir(page)
+        if vd is None:
+            raise ValueError(f"Page '{page}' not found.")
+
+        members: list[tuple[Path, dict[str, Any]]] = []
+        for name in member_names:
+            found = self._ga_find_visual_json(page, name)
+            if found:
+                members.append(found)
+        if len(members) < 2:
+            raise ValueError("A group needs at least two existing member visuals.")
+
+        # Bounding box across members
+        xs = [m[1].get("position", {}).get("x", 0) for m in members]
+        ys = [m[1].get("position", {}).get("y", 0) for m in members]
+        x2 = [m[1].get("position", {}).get("x", 0) + m[1].get("position", {}).get("width", 0)
+              for m in members]
+        y2 = [m[1].get("position", {}).get("y", 0) + m[1].get("position", {}).get("height", 0)
+              for m in members]
+        gx, gy = min(xs), min(ys)
+        gw, gh = max(x2) - gx, max(y2) - gy
+
+        group_id = uuid.uuid4().hex[:20]
+        group_display = display_name or "Group"
+        group_dir = vd / group_id
+        group_dir.mkdir(exist_ok=True)
+        group_json: dict[str, Any] = {
+            "$schema": VISUAL_CONTAINER_SCHEMA,
+            "name": group_id,
+            "position": {"x": gx, "y": gy, "z": 1, "height": gh, "width": gw, "tabOrder": 1},
+            "visualGroup": {"displayName": group_display, "groupMode": group_mode},
+        }
+        (group_dir / "visual.json").write_text(
+            json.dumps(group_json, indent=2), encoding="utf-8"
+        )
+
+        # Tag each member with parentGroupName (top-level key)
+        for vj, data in members:
+            data["parentGroupName"] = group_id
+            vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+        return {"name": group_id, "displayName": group_display,
+                "members": [m[1].get("name") for m in members]}
+
+    # ── Mobile layout ──────────────────────────────────────────────────────────
+    # Each visual's mobile position is a sibling mobile.json (visualContainerMobileState).
+
+    MOBILE_STATE_SCHEMA = (
+        "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/"
+        "visualContainerMobileState/2.5.0/schema.json"
+    )
+
+    def visual_set_mobile(
+        self,
+        page: str,
+        visual_name: str,
+        x: int,
+        y: int,
+        width: int,
+        height: int,
+        z: int = 1,
+        tab_order: int = 0,
+    ) -> bool:
+        """Set a visual's position on the mobile (phone) layout canvas.
+
+        Writes a mobile.json beside the visual's visual.json. The mobile canvas
+        is 320 units wide. PBIR GA only. Returns True if the visual was found.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Mobile layout requires PBIR GA format (definition/ folder).")
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return False
+        vj, _ = found
+        mobile = {
+            "$schema": self.MOBILE_STATE_SCHEMA,
+            "position": {
+                "x": x, "y": y, "z": z, "height": height, "width": width, "tabOrder": tab_order
+            },
+        }
+        (vj.parent / "mobile.json").write_text(json.dumps(mobile, indent=2), encoding="utf-8")
         return True
 
     # ── Helpers ────────────────────────────────────────────────────────────────

--- a/src/pbi_cli/cli.py
+++ b/src/pbi_cli/cli.py
@@ -40,6 +40,7 @@ from pbi_cli.commands import (  # noqa: E402
     ops_cmd,
     partition,
     pquery_cmd,
+    project_cmd,
     repl,
     report,
     security,
@@ -161,6 +162,7 @@ cli.add_command(measure.measure)
 cli.add_command(model.model)
 cli.add_command(dax.dax)
 cli.add_command(report.report)
+cli.add_command(project_cmd.project)
 cli.add_command(visual.visual)
 cli.add_command(layout.layout)
 cli.add_command(theme.theme)

--- a/src/pbi_cli/commands/project_cmd.py
+++ b/src/pbi_cli/commands/project_cmd.py
@@ -1,0 +1,42 @@
+"""pbi project — scaffold complete, openable PBIP projects from scratch."""
+
+from __future__ import annotations
+
+import click
+from rich.console import Console
+
+from pbi_cli.commands._shared import dry_run_echo
+
+console = Console(legacy_windows=False)
+
+
+@click.group()
+def project() -> None:
+    """Create and manage complete .pbip projects (model + report)."""
+
+
+@project.command("new")
+@click.option("--out", required=True, help="Output directory the project folder is created in.")
+@click.option("--name", default="New Report", show_default=True, help="Project / report name.")
+@click.option("--table", default="Financials", show_default=True, help="Sample model table name.")
+@click.pass_context
+def project_new(ctx: click.Context, out: str, name: str, table: str) -> None:
+    """Scaffold a complete, openable PBIP (offline model with sample data + report).
+
+    The result opens directly in Power BI Desktop with no data source to connect —
+    the model uses entered data. Enable the PBIR preview feature in Desktop first.
+
+    \b
+    Example:
+      pbi project new --out "C:/Users/Me/Documents" --name "Sales Demo"
+    """
+    if dry_run_echo(ctx, f"scaffold openable PBIP '{name}' in '{out}'"):
+        return
+    from pbi_cli.project_scaffold import create_project
+
+    pbip_path = create_project(out, name=name, table=table)
+    console.print(f"[green]Project created:[/green] {pbip_path}")
+    console.print(
+        "[yellow]Tip:[/yellow] Open the .pbip in Power BI Desktop "
+        "(PBIR preview feature must be enabled), then click Refresh to load sample data."
+    )

--- a/src/pbi_cli/commands/report.py
+++ b/src/pbi_cli/commands/report.py
@@ -387,27 +387,61 @@ def report_bookmark_list(ctx: click.Context, pbip: str) -> None:
 @click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
 @click.option("--name", required=True, help="Display name for the bookmark.")
 @click.option("--page", default=None, help="Page to associate with the bookmark.")
+@click.option(
+    "--hidden-visual",
+    "hidden_visuals",
+    multiple=True,
+    help="Visual name to record as hidden in this bookmark (repeatable). "
+    "Builds show/hide storytelling bookmarks.",
+)
+@click.option(
+    "--no-capture",
+    is_flag=True,
+    default=False,
+    help="Write an empty bookmark skeleton instead of capturing the page's visuals.",
+)
 @click.pass_context
-def report_bookmark_add(ctx: click.Context, pbip: str, name: str, page: str | None) -> None:
+def report_bookmark_add(
+    ctx: click.Context,
+    pbip: str,
+    name: str,
+    page: str | None,
+    hidden_visuals: tuple[str, ...],
+    no_capture: bool,
+) -> None:
     """Add a named bookmark to a .pbip report.
 
-    The bookmark captures the current report state when reloaded in Power BI Desktop.
+    By default the bookmark captures the visuals on the target page, so it
+    survives reopening in Desktop. Use --hidden-visual to record specific
+    visuals as hidden (for show/hide bookmarks).
 
     \b
-    Example:
+    Examples:
       pbi report bookmark-add --pbip MyReport --name "Q4 View" --page "Sales"
+      pbi report bookmark-add --pbip MyReport --name "Detail hidden" --page "Sales" \\
+        --hidden-visual detail_table_abc --hidden-visual notes_xyz
     """
     if dry_run_echo(ctx, f"add bookmark '{name}'" + (f" on page '{page}'" if page else "")):
         return
     from pbi_cli.backends.pbir_backend import PbirBackend
 
     b = PbirBackend(pbip)
-    result = b.bookmark_add(name, page=page)
+    result = b.bookmark_add(
+        name,
+        page=page,
+        hidden_visuals=list(hidden_visuals) or None,
+        capture=not no_capture,
+    )
     console.print(f"[green]Bookmark added:[/green] '{name}'  (id: {result['name']})")
     if page:
         console.print(f"  Linked to page: {page}")
+    captured = result.get("options", {}).get("targetVisualNames", [])
+    if not no_capture and captured:
+        console.print(f"  Captured {len(captured)} visual(s)" + (
+            f", {len(hidden_visuals)} hidden" if hidden_visuals else ""
+        ))
     console.print(
-        "[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to capture visual state."
+        "[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to refine the captured state."
     )
 
 
@@ -652,3 +686,109 @@ def report_a11y(ctx: click.Context, pbip: str, fail_on: str) -> None:
     worst = max((rank.get(v["severity"], 0) for v in findings), default=0)
     if worst >= rank[fail_on]:
         raise SystemExit(3)
+
+
+# ── Report-level measures ────────────────────────────────────────────────────────
+
+
+@report.command("measure-add")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--table", required=True, help="Target table (entity) in the semantic model.")
+@click.option("--name", required=True, help="Measure name.")
+@click.option("--expression", required=True, help="DAX expression.")
+@click.option("--format-string", default=None, help="Optional format string, e.g. '0.0%'.")
+@click.option(
+    "--data-type",
+    default="Double",
+    show_default=True,
+    type=click.Choice(["Double", "Integer", "Text", "Boolean", "DateTime", "Decimal"]),
+    help="Measure data type (required by the schema).",
+)
+@click.pass_context
+def report_measure_add(
+    ctx: click.Context,
+    pbip: str,
+    table: str,
+    name: str,
+    expression: str,
+    format_string: str | None,
+    data_type: str,
+) -> None:
+    """Add a report-level measure (stored in reportExtensions.json).
+
+    \b
+    Example:
+      pbi report measure-add --pbip MyReport --table financials \
+        --name "Margin %" --expression "DIVIDE(SUM(financials[Profit]),SUM(financials[Sales]))" \
+        --format-string "0.0%"
+    """
+    if dry_run_echo(ctx, f"add report-level measure '{name}' on table '{table}'"):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        b.report_measure_add(
+            table, name, expression, format_string=format_string, data_type=data_type
+        )
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    console.print(f"[green]Report-level measure added:[/green] {table}[{name}]")
+    console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see it.")
+
+
+@report.command("measure-list")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.pass_context
+def report_measure_list(ctx: click.Context, pbip: str) -> None:
+    """List report-level measures defined in reportExtensions.json."""
+    from pbi_cli.backends.pbir_backend import PbirBackend
+    from pbi_cli.commands._shared import output_json_or_table
+
+    b = PbirBackend(pbip)
+    measures = b.report_measure_list()
+    if not measures:
+        console.print("[yellow]No report-level measures.[/yellow]")
+        return
+    output_json_or_table(measures, ctx, title="Report-level Measures")
+
+
+# ── Bookmark groups ──────────────────────────────────────────────────────────────
+
+
+@report.command("bookmark-group-add")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--name", required=True, help="Display name for the group.")
+@click.option(
+    "--member",
+    "members",
+    multiple=True,
+    required=True,
+    help="Display name of a bookmark to include (repeatable).",
+)
+@click.pass_context
+def report_bookmark_group_add(
+    ctx: click.Context, pbip: str, name: str, members: tuple[str, ...]
+) -> None:
+    """Group existing bookmarks under a named bookmark group.
+
+    \b
+    Example:
+      pbi report bookmark-group-add --pbip MyReport --name "Story" \
+        --member "Intro" --member "Detail"
+    """
+    if dry_run_echo(ctx, f"create bookmark group '{name}' with {len(members)} member(s)"):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        result = b.bookmark_group_add(name, list(members))
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    console.print(
+        f"[green]Bookmark group created:[/green] '{name}' "
+        f"({len(result['members'])} member(s))"
+    )

--- a/src/pbi_cli/commands/visual.py
+++ b/src/pbi_cli/commands/visual.py
@@ -308,6 +308,67 @@ def visual_delete(ctx: click.Context, pbip: str, page: str, visual_name: str) ->
     console.print(f"[green]Deleted[/green] visual '{visual_name}' from '{page}'.")
 
 
+@visual.command("update")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Page display name.")
+@click.option("--name", "visual_name", required=True, help="Visual name (from pbi visual list).")
+@click.option("--x", type=int, default=None, help="New x position.")
+@click.option("--y", type=int, default=None, help="New y position.")
+@click.option("--z", type=int, default=None, help="New z (stacking) order.")
+@click.option("--width", type=int, default=None, help="New width.")
+@click.option("--height", type=int, default=None, help="New height.")
+@click.option("--tab-order", type=int, default=None, help="New tab order.")
+@click.option("--title", default=None, help="New visual title text.")
+@click.pass_context
+def visual_update(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    visual_name: str,
+    x: int | None,
+    y: int | None,
+    z: int | None,
+    width: int | None,
+    height: int | None,
+    tab_order: int | None,
+    title: str | None,
+) -> None:
+    """Patch an existing visual's position and/or title in place.
+
+    Only the options you pass are changed; query bindings and formatting are
+    preserved. To rebind fields, delete the visual and re-add it.
+
+    \b
+    Example — move and retitle:
+      pbi visual update --pbip MyReport --page "Sales" --name abc123 \\
+        --x 40 --y 40 --width 480 --title "Revenue by Region"
+    """
+    if all(v is None for v in (x, y, z, width, height, tab_order, title)):
+        raise click.UsageError("Pass at least one property to change (e.g. --x, --title).")
+    if dry_run_echo(ctx, f"update visual '{visual_name}' on page '{page}'"):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    ok = b.visual_update(
+        page,
+        visual_name,
+        x=x,
+        y=y,
+        z=z,
+        width=width,
+        height=height,
+        tab_order=tab_order,
+        title=title,
+    )
+    if ok:
+        console.print(f"[green]Updated[/green] visual '{visual_name}' on '{page}'.")
+        console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
+    else:
+        console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
+        raise SystemExit(1)
+
+
 @visual.command("recommend")
 @click.option("--measures", required=True, help="Comma-separated measure names.")
 @click.pass_context
@@ -397,6 +458,42 @@ def _next_position(backend: Any, page: str, w: int, h: int) -> tuple[int, int]:
     return GUTTER, max_y + GUTTER
 
 
+def _parse_rules(rules: tuple[str, ...]) -> list[tuple]:
+    """Parse rule strings into tuples.
+
+    'OP:THRESHOLD:VALUE'        -> (op, threshold, value)
+    'between:LOW:HIGH:VALUE'    -> ('between', low, high, value)
+
+    VALUE is a hex colour (for colour rules) or an icon name (for icon rules).
+    """
+    parsed: list[tuple] = []
+    for raw in rules:
+        parts = [p.strip() for p in raw.split(":")]
+        if parts and parts[0] == "between":
+            if len(parts) != 4:
+                raise click.UsageError(
+                    f"Invalid --rule '{raw}'. Expected 'between:LOW:HIGH:VALUE'."
+                )
+            try:
+                low, high = float(parts[1]), float(parts[2])
+            except ValueError:
+                raise click.UsageError(f"Invalid numbers in rule '{raw}'.")
+            parsed.append(("between", low, high, parts[3]))
+            continue
+        if len(parts) != 3:
+            raise click.UsageError(
+                f"Invalid --rule '{raw}'. Expected 'OP:THRESHOLD:VALUE' or "
+                "'between:LOW:HIGH:VALUE'."
+            )
+        op, threshold, value = parts
+        try:
+            num = float(threshold)
+        except ValueError:
+            raise click.UsageError(f"Invalid threshold '{threshold}' in rule '{raw}'.")
+        parsed.append((op, num, value))
+    return parsed
+
+
 # ── Conditional Formatting ─────────────────────────────────────────────────────
 
 
@@ -407,12 +504,26 @@ def _next_position(backend: Any, page: str, w: int, h: int) -> tuple[int, int]:
 @click.option(
     "--type",
     "fmt_type",
-    type=click.Choice(["color-scale", "data-bar"]),
+    type=click.Choice(["color-scale", "data-bar", "rules", "icons"]),
     required=True,
     help="Conditional formatting type.",
 )
 @click.option("--table", required=True, help="Table name containing the measure.")
 @click.option("--measure", required=True, help="Measure name to apply formatting to.")
+@click.option(
+    "--rule",
+    "rules",
+    multiple=True,
+    help="Rule for --type rules, as 'OP:THRESHOLD:#HEX' (e.g. '>=:1000000:#00FF00'). "
+    "Repeatable; evaluated top-to-bottom, first match wins.",
+)
+@click.option(
+    "--target",
+    type=click.Choice(["fill", "text"]),
+    default="fill",
+    show_default=True,
+    help="What --type rules colours: cell fill (backColor) or text (fontColor).",
+)
 @click.option(
     "--low-color", default="#FF0000", show_default=True, help="Low value color (color-scale)."
 )
@@ -446,6 +557,8 @@ def visual_format(
     fmt_type: str,
     table: str,
     measure: str,
+    rules: tuple[str, ...],
+    target: str,
     low_color: str,
     mid_color: str,
     high_color: str,
@@ -465,6 +578,12 @@ def visual_format(
       pbi visual format --pbip MyReport --page "Sales" --visual abc123 \\
         --type data-bar --table financials --measure Profit \\
         --positive-color "#118DFF" --negative-color "#FC4E2A"
+
+    \b
+    Rule-based example (text colour by threshold, first match wins):
+      pbi visual format --pbip MyReport --page "Sales" --visual abc123 \\
+        --type rules --target text --table financials --measure Profit \\
+        --rule ">=:100000:#107C10" --rule ">=:0:#D83B01" --rule "<:0:#A4262C"
     """
     if dry_run_echo(
         ctx,
@@ -476,7 +595,23 @@ def visual_format(
 
     b = PbirBackend(pbip)
 
-    if fmt_type == "color-scale":
+    if fmt_type == "rules":
+        if not rules:
+            raise click.UsageError("--type rules requires at least one --rule OP:THRESHOLD:#HEX.")
+        parsed = _parse_rules(rules)
+        found = b.visual_format_rules(
+            page,
+            visual_name,
+            table,
+            measure,
+            parsed,
+            target="fontColor" if target == "text" else "backColor",
+        )
+    elif fmt_type == "icons":
+        # No --rule => Desktop's default 3-band percent icon set.
+        parsed_icons = _parse_rules(rules) if rules else None
+        found = b.visual_format_icons(page, visual_name, table, measure, rules=parsed_icons)
+    elif fmt_type == "color-scale":
         found = b.visual_format_color_scale(
             page,
             visual_name,
@@ -502,6 +637,349 @@ def visual_format(
             f"{fmt_type} on {table}[{measure}] in visual '{visual_name}'"
         )
         console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
+    else:
+        console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
+        raise SystemExit(1)
+
+
+# ── Visual interactions & slicer sync ───────────────────────────────────────────
+
+
+@visual.command("interaction")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Page display name.")
+@click.option("--source", required=True, help="Source visual name (the one being clicked).")
+@click.option("--target", required=True, help="Target visual name (the one that reacts).")
+@click.option(
+    "--type",
+    "interaction_type",
+    type=click.Choice(["Default", "DataFilter", "HighlightFilter", "NoFilter"]),
+    required=True,
+    help="How the source filters the target. NoFilter = no cross-filtering.",
+)
+@click.pass_context
+def visual_interaction(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    source: str,
+    target: str,
+    interaction_type: str,
+) -> None:
+    """Set how one visual cross-filters another on a page (PBIR GA only).
+
+    \b
+    Example — stop a slicer from filtering a KPI card:
+      pbi visual interaction --pbip MyReport --page "Sales" \\
+        --source slicer_abc --target card_xyz --type NoFilter
+    """
+    if dry_run_echo(
+        ctx, f"set interaction {source} -> {target} = {interaction_type} on '{page}'"
+    ):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        b.set_visual_interaction(page, source, target, interaction_type)
+    except (ValueError, RuntimeError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    console.print(
+        f"[green]Interaction set:[/green] {source} → {target} = {interaction_type} on '{page}'"
+    )
+    console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
+
+
+@visual.command("sync-slicer")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Page display name containing the slicer.")
+@click.option("--name", "visual_name", required=True, help="Slicer visual name.")
+@click.option("--group", required=True, help="Sync group name; slicers sharing it stay in sync.")
+@click.option(
+    "--no-field-changes",
+    is_flag=True,
+    default=False,
+    help="Do not sync when the slicer field changes.",
+)
+@click.option(
+    "--no-filter-changes",
+    is_flag=True,
+    default=False,
+    help="Do not sync when the slicer selection changes.",
+)
+@click.pass_context
+def visual_sync_slicer(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    visual_name: str,
+    group: str,
+    no_field_changes: bool,
+    no_filter_changes: bool,
+) -> None:
+    """Add a slicer to a named sync group so it stays in sync across pages (PBIR GA).
+
+    Run this on each slicer that should be synced, passing the same --group.
+
+    \b
+    Example:
+      pbi visual sync-slicer --pbip MyReport --page "Sales" --name slicer_abc --group "Region"
+    """
+    if dry_run_echo(ctx, f"sync slicer '{visual_name}' into group '{group}' on '{page}'"):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        ok = b.set_slicer_sync(
+            page,
+            visual_name,
+            group,
+            field_changes=not no_field_changes,
+            filter_changes=not no_filter_changes,
+        )
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    if ok:
+        console.print(f"[green]Slicer synced:[/green] '{visual_name}' → group '{group}'")
+        console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
+    else:
+        console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
+        raise SystemExit(1)
+
+
+# ── Field rebinding ──────────────────────────────────────────────────────────────
+
+
+@visual.command("set-field")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Page display name.")
+@click.option("--name", "visual_name", required=True, help="Visual name (from pbi visual list).")
+@click.option("--role", required=True, help="Visual role slot, e.g. Category, Y, Values, Rows.")
+@click.option("--table", required=True, help="Table (entity) of the field to bind.")
+@click.option("--field", required=True, help="Column or measure name to bind.")
+@click.option("--measure", "is_measure", is_flag=True, help="The field is an explicit DAX measure.")
+@click.option(
+    "--agg",
+    type=click.Choice(["sum", "avg", "min", "max", "count", "none"]),
+    default="sum",
+    show_default=True,
+    help="Aggregation for a column ('none' = no aggregation).",
+)
+@click.option("--append", is_flag=True, help="Append to the role instead of replacing it.")
+@click.pass_context
+def visual_set_field(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    visual_name: str,
+    role: str,
+    table: str,
+    field: str,
+    is_measure: bool,
+    agg: str,
+    append: bool,
+) -> None:
+    """Rebind which field a visual role uses (rewrites the query projection).
+
+    \b
+    Example — swap a chart's value from Sales to Profit:
+      pbi visual set-field --pbip MyReport --page "Sales" --name abc123 \\
+        --role Y --table financials --field Profit
+    """
+    if dry_run_echo(ctx, f"set {role} = {table}[{field}] on visual '{visual_name}'"):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    agg_val = AGG_MAP[agg]
+    b = PbirBackend(pbip)
+    try:
+        ok = b.visual_set_field(
+            page,
+            visual_name,
+            role,
+            table,
+            field,
+            is_measure=is_measure,
+            agg=None if agg_val < 0 else agg_val,
+            replace=not append,
+        )
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    if ok:
+        console.print(
+            f"[green]Bound[/green] {role} = {table}[{field}] on visual '{visual_name}'."
+        )
+        console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
+    else:
+        console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
+        raise SystemExit(1)
+
+
+# ── Non-data elements: textbox, buttons, navigators ─────────────────────────────
+
+
+@visual.command("add-element")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Page display name to add the element to.")
+@click.option(
+    "--type",
+    "element_type",
+    type=click.Choice(["textbox", "button", "page-nav", "bookmark-nav"]),
+    required=True,
+    help="Element type.",
+)
+@click.option("--text", default=None, help="Text content (textbox) or label (button).")
+@click.option("--shape", default="blank", show_default=True, help="Button shape (button only).")
+@click.option("--x", type=int, default=16, show_default=True)
+@click.option("--y", type=int, default=16, show_default=True)
+@click.option("--width", type=int, default=300, show_default=True)
+@click.option("--height", type=int, default=80, show_default=True)
+@click.pass_context
+def visual_add_element(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    element_type: str,
+    text: str | None,
+    shape: str,
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+) -> None:
+    """Add a non-data element (textbox, button, page/bookmark navigator) to a page.
+
+    \b
+    Examples:
+      pbi visual add-element --pbip R --page "Sales" --type textbox --text "Q4 Review"
+      pbi visual add-element --pbip R --page "Sales" --type page-nav --width 800 --height 60
+    """
+    if dry_run_echo(ctx, f"add {element_type} element to page '{page}'"):
+        return
+    from pbi_cli.intelligence.visual_builder import (
+        VisualSpec,
+        build_action_button,
+        build_bookmark_navigator,
+        build_page_navigator,
+        build_textbox,
+    )
+
+    if element_type == "textbox":
+        body = build_textbox(text or "")
+    elif element_type == "button":
+        body = build_action_button(shape=shape, text=text)
+    elif element_type == "page-nav":
+        body = build_page_navigator()
+    else:
+        body = build_bookmark_navigator()
+
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    spec = VisualSpec(
+        visual_type=body["visualType"],
+        visual_body=body,
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+    )
+    result = b.visual_add(page, spec)
+    console.print(
+        f"[green]Added[/green] {element_type} '{result['name']}' to page '{page}'."
+    )
+    console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see it.")
+
+
+# ── Visual groups & mobile layout ───────────────────────────────────────────────
+
+
+@visual.command("group")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Page display name.")
+@click.option(
+    "--member",
+    "members",
+    multiple=True,
+    required=True,
+    help="Visual name to include in the group (repeatable; at least two).",
+)
+@click.option("--name", "display_name", default=None, help="Group display name.")
+@click.pass_context
+def visual_group(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    members: tuple,
+    display_name,
+) -> None:
+    """Group existing visuals on a page so they move/resize together.
+
+    
+    Example:
+      pbi visual group --pbip R --page "Sales" --member card_a --member card_b --name "KPIs"
+    """
+    if dry_run_echo(ctx, f"group {len(members)} visuals on page '{page}'"):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        result = b.visual_group_add(page, list(members), display_name=display_name)
+    except (ValueError, RuntimeError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    console.print(
+        f"[green]Grouped[/green] {len(result['members'])} visuals "
+        f"as '{result['displayName']}' (id: {result['name']})."
+    )
+    console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see it.")
+
+
+@visual.command("mobile")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Page display name.")
+@click.option("--name", "visual_name", required=True, help="Visual name.")
+@click.option("--x", type=int, required=True, help="X on the mobile canvas (320 wide).")
+@click.option("--y", type=int, required=True, help="Y on the mobile canvas.")
+@click.option("--width", type=int, required=True, help="Width on the mobile canvas.")
+@click.option("--height", type=int, required=True, help="Height on the mobile canvas.")
+@click.pass_context
+def visual_mobile(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    visual_name: str,
+    x: int,
+    y: int,
+    width: int,
+    height: int,
+) -> None:
+    """Place a visual on the phone (mobile) layout canvas.
+
+    The mobile canvas is 320 units wide. Writes a mobile.json beside the visual.
+
+    
+    Example:
+      pbi visual mobile --pbip R --page "Sales" --name card_a --x 0 --y 0 --width 320 --height 120
+    """
+    if dry_run_echo(ctx, f"set mobile layout for visual '{visual_name}' on '{page}'"):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        ok = b.visual_set_mobile(page, visual_name, x, y, width, height)
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    if ok:
+        console.print(f"[green]Mobile layout set[/green] for '{visual_name}' on '{page}'.")
+        console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see it.")
     else:
         console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
         raise SystemExit(1)

--- a/src/pbi_cli/intelligence/visual_builder.py
+++ b/src/pbi_cli/intelligence/visual_builder.py
@@ -269,6 +269,57 @@ def build_ribbon_chart(
     }
 
 
+# ── Non-data elements: textbox, buttons, navigators ─────────────────────────────
+# These have no query bindings. Shapes verified against Power BI Desktop output:
+# a blank button serialises as visualType "actionButton" with objects.icon.shapeType;
+# page/bookmark navigators serialise as just their visualType.
+
+
+def build_textbox(text: str = "") -> dict[str, Any]:
+    """A textbox. Rich text lives in objects.general[].paragraphs[].textRuns."""
+    body: dict[str, Any] = {"visualType": "textbox", "objects": {}, "visualContainerObjects": {}}
+    if text:
+        body["objects"]["general"] = [
+            {"properties": {"paragraphs": [{"textRuns": [{"value": text}]}]}}
+        ]
+    return body
+
+
+def build_action_button(shape: str = "blank", text: str | None = None) -> dict[str, Any]:
+    """An action button. shape: 'blank' | 'back' | 'reset' | 'bookmark' | ...
+
+    Matches Desktop: objects.icon[].properties.shapeType with selector id 'default'.
+    """
+    body: dict[str, Any] = {
+        "visualType": "actionButton",
+        "objects": {
+            "icon": [
+                {
+                    "properties": {"shapeType": {"expr": {"Literal": {"Value": f"'{shape}'"}}}},
+                    "selector": {"id": "default"},
+                }
+            ]
+        },
+        "visualContainerObjects": {},
+    }
+    if text:
+        body["objects"]["text"] = [
+            {
+                "properties": {"text": {"expr": {"Literal": {"Value": f"'{text}'"}}}},
+                "selector": {"id": "default"},
+            }
+        ]
+    return body
+
+
+def build_page_navigator() -> dict[str, Any]:
+    return {"visualType": "pageNavigator", "objects": {}, "visualContainerObjects": {}}
+
+
+def build_bookmark_navigator() -> dict[str, Any]:
+    return {"visualType": "bookmarkNavigator", "objects": {}, "visualContainerObjects": {}}
+
+
 # ── VisualSpec and serialisation ───────────────────────────────────────────────
 
 

--- a/src/pbi_cli/project_scaffold.py
+++ b/src/pbi_cli/project_scaffold.py
@@ -1,0 +1,228 @@
+"""Scaffold a complete, openable PBIP project from scratch.
+
+Produces a .pbip with an offline import semantic model (entered data via an M
+#table — no external data source) and a starter PBIR report. The model is
+written with the `ref table` / `ref cultureInfo` lines that Power BI Desktop
+requires (TMDL does not auto-discover table files), so the project opens cleanly.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+
+from pbi_cli.backends.pbir_backend import PbirBackend
+from pbi_cli.intelligence.visual_builder import (
+    AGG_SUM,
+    FieldDef,
+    VisualSpec,
+    build_bar_chart,
+    build_card,
+    build_line_chart,
+    build_table,
+)
+from pbi_cli.tmdl_util import ensure_ref_culture, ensure_ref_table
+
+# Default sample schema: (column, tmdl dtype, summarizeBy)
+_COLUMNS = [
+    ("Country", "string", "none"),
+    ("Segment", "string", "none"),
+    ("Year", "string", "none"),
+    ("Month", "string", "none"),
+    ("Sales", "double", "sum"),
+    ("Profit", "double", "sum"),
+    ("Units Sold", "int64", "sum"),
+    ("COGS", "double", "sum"),
+]
+
+
+def _platform(item_type: str, display: str) -> str:
+    return json.dumps(
+        {
+            "$schema": "https://developer.microsoft.com/json-schemas/fabric/"
+            "gitIntegration/platformProperties/2.0.0/schema.json",
+            "metadata": {"type": item_type, "displayName": display},
+            "config": {"version": "2.0", "logicalId": str(uuid.uuid4())},
+        },
+        indent=2,
+    )
+
+
+def _sample_rows() -> list[list[Any]]:
+    countries = ["USA", "Canada", "France", "Germany"]
+    segments = {"USA": "Enterprise", "Canada": "Midmarket",
+                "France": "Government", "Germany": "Channel"}
+    months = ["01-Jan", "02-Feb", "03-Mar", "04-Apr", "05-May", "06-Jun",
+              "07-Jul", "08-Aug", "09-Sep", "10-Oct", "11-Nov", "12-Dec"]
+    rows: list[list[Any]] = []
+    for y, year in enumerate(["2023", "2024"]):
+        for c, country in enumerate(countries):
+            for m, month in enumerate(months):
+                base = 4000 + c * 1500 + m * 350 + y * 2000
+                sales = base + ((m * 7 + c * 13) % 9) * 220
+                cogs = round(sales * (0.55 + 0.03 * c), 0)
+                rows.append([country, segments[country], year, month,
+                             float(sales), float(sales - cogs),
+                             80 + c * 20 + m * 5 + y * 30, float(cogs)])
+    return rows
+
+
+def _m_table(rows: list[list[Any]]) -> str:
+    def lit(v: Any) -> str:
+        if isinstance(v, str):
+            return f'"{v}"'
+        return str(int(v)) if isinstance(v, int) else str(v)
+
+    row_lines = ",\n\t\t\t\t\t".join(
+        "{" + ", ".join(lit(v) for v in r) + "}" for r in rows
+    )
+    return (
+        "let\n"
+        "\t\t\t\tSource = #table(\n"
+        "\t\t\t\t\ttype table [Country = text, Segment = text, Year = text, Month = text, "
+        'Sales = number, Profit = number, #"Units Sold" = Int64.Type, COGS = number],\n'
+        "\t\t\t\t\t{\n\t\t\t\t\t" + row_lines + "\n\t\t\t\t\t}\n"
+        "\t\t\t\t)\n"
+        "\t\t\tin\n"
+        "\t\t\t\tSource"
+    )
+
+
+def _write_model(root: Path, name: str, table: str) -> None:
+    sm = root / f"{name}.SemanticModel"
+    (sm / "definition" / "tables").mkdir(parents=True, exist_ok=True)
+    (sm / "definition" / "cultures").mkdir(parents=True, exist_ok=True)
+    (sm / ".platform").write_text(_platform("SemanticModel", name), encoding="utf-8")
+    (sm / "definition.pbism").write_text(
+        json.dumps(
+            {
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/"
+                "item/semanticModel/definitionProperties/1.0.0/schema.json",
+                "version": "4.2",
+                "settings": {},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (sm / "definition" / "database.tmdl").write_text(
+        "database\n\tcompatibilityLevel: 1550\n", encoding="utf-8"
+    )
+    # TMDL requires explicit ref table / ref cultureInfo lines — Desktop will not
+    # auto-discover table files. Omitting them yields a model with no tables, so
+    # the references are added via the shared, idempotent tmdl_util helpers.
+    model_tmdl = sm / "definition" / "model.tmdl"
+    model_tmdl.write_text(
+        "model Model\n"
+        "\tculture: en-US\n"
+        "\tdefaultPowerBIDataSourceVersion: powerBI_V3\n"
+        "\tdiscourageImplicitMeasures\n"
+        "\tsourceQueryCulture: en-US\n"
+        "\tdataAccessOptions\n"
+        "\t\tlegacyRedirects\n"
+        "\t\treturnErrorValuesAsNull\n\n"
+        f'\tannotation PBI_QueryOrder = ["{table}"]\n\n'
+        '\tannotation PBI_ProTooling = ["DevMode"]\n',
+        encoding="utf-8",
+    )
+    ensure_ref_table(model_tmdl, table)
+    ensure_ref_culture(model_tmdl, "en-US")
+    (sm / "definition" / "cultures" / "en-US.tmdl").write_text(
+        "cultureInfo en-US\n", encoding="utf-8"
+    )
+
+    parts = [f"table {table}\n"]
+    for cname, dtype, summ in _COLUMNS:
+        obj = f"'{cname}'" if " " in cname else cname
+        parts.append(
+            f"\n\tcolumn {obj}\n\t\tdataType: {dtype}\n"
+            f"\t\tsummarizeBy: {summ}\n\t\tsourceColumn: {cname}\n"
+        )
+    parts.append(
+        f"\n\tmeasure 'Profit Margin %' = "
+        f"DIVIDE(SUM({table}[Profit]), SUM({table}[Sales]))\n\t\tformatString: 0.0%\n"
+    )
+    parts.append(
+        f"\n\tpartition {table} = m\n\t\tmode: import\n\t\tsource =\n"
+        "\t\t\t" + _m_table(_sample_rows()) + "\n"
+    )
+    (sm / "definition" / "tables" / f"{table}.tmdl").write_text("".join(parts), encoding="utf-8")
+
+
+def _write_report(root: Path, name: str, table: str) -> PbirBackend:
+    rep = root / f"{name}.Report"
+    rep.mkdir(parents=True, exist_ok=True)
+    (rep / ".platform").write_text(_platform("Report", name), encoding="utf-8")
+    (rep / "definition.pbir").write_text(
+        json.dumps(
+            {
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/"
+                "item/report/definitionProperties/2.0.0/schema.json",
+                "version": "4.0",
+                "datasetReference": {"byPath": {"path": f"../{name}.SemanticModel"}},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    b = PbirBackend(str(root))  # creates definition/ + report.json (PBIR GA)
+    (rep / "definition" / "version.json").write_text(
+        json.dumps(
+            {
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/"
+                "item/report/definition/versionMetadata/1.0.0/schema.json",
+                "version": "2.0.0",
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return b
+
+
+def _build_report(b: PbirBackend, table: str) -> None:
+    def col(p: str) -> FieldDef:
+        return FieldDef(entity=table, property=p, is_measure=False, agg=None)
+
+    def agg(p: str) -> FieldDef:
+        return FieldDef(entity=table, property=p, agg=AGG_SUM)
+
+    page = "Overview"
+    b.page_add(page)
+    for i, (prop, title) in enumerate([("Sales", "Total Sales"), ("Profit", "Total Profit")]):
+        b.visual_add(page, VisualSpec("card", build_card(agg(prop)),
+                                      x=16 + i * 296, y=16, width=280, height=120, title=title))
+    b.visual_add(page, VisualSpec("barChart", build_bar_chart(col("Country"), agg("Sales")),
+                                  x=16, y=152, width=600, height=320, title="Sales by Country"))
+    b.visual_add(page, VisualSpec("lineChart", build_line_chart(col("Month"), agg("Sales")),
+                                  x=632, y=152, width=632, height=320, title="Sales by Month"))
+    b.visual_add(page, VisualSpec(
+        "tableEx", build_table([col("Country"), agg("Sales"), agg("Profit")]),
+        x=16, y=488, width=1248, height=216, title="Detail"))
+
+
+def create_project(
+    out_dir: str | Path, name: str = "New Report", table: str = "Financials"
+) -> Path:
+    """Create an openable PBIP under out_dir/<name>/ and return the .pbip path."""
+    root = Path(out_dir) / name
+    root.mkdir(parents=True, exist_ok=True)
+    (root / f"{name}.pbip").write_text(
+        json.dumps(
+            {
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/"
+                "pbip/pbipProperties/1.0.0/schema.json",
+                "version": "1.0",
+                "artifacts": [{"report": {"path": f"{name}.Report"}}],
+                "settings": {"enableAutoRecovery": True},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    _write_model(root, name, table)
+    b = _write_report(root, name, table)
+    _build_report(b, table)
+    return root / f"{name}.pbip"

--- a/src/pbi_cli/tmdl_util.py
+++ b/src/pbi_cli/tmdl_util.py
@@ -1,0 +1,125 @@
+"""Helpers for the TMDL `model.tmdl` reference block.
+
+TMDL does *not* auto-discover table files: a semantic model only loads a table
+if `model.tmdl` carries a matching top-level `ref table <name>` line (and a
+`ref cultureInfo <c>` line for each culture under `definition/cultures/`). A
+table `.tmdl` file with no `ref table` line loads with that table silently
+missing in Power BI Desktop.
+
+Any pure-Python path that writes or removes a table `.tmdl` file must keep these
+references in sync. These helpers are idempotent so callers can apply them
+unconditionally. `project_scaffold._write_model` is the reference shape.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REF_TABLE_RE = re.compile(r"^ref\s+table\s+(?P<name>.+?)\s*$")
+_REF_CULTURE_RE = re.compile(r"^ref\s+cultureInfo\s+(?P<name>.+?)\s*$")
+
+
+def quote_tmdl_name(name: str) -> str:
+    """Quote a TMDL object name the same way table declarations are quoted.
+
+    Bare identifiers (letters, digits, underscore) are left unquoted; anything
+    else is single-quoted with embedded quotes doubled — e.g. `Units Sold`
+    becomes `'Units Sold'`.
+    """
+    if re.fullmatch(r"[A-Za-z0-9_]+", name):
+        return name
+    return "'" + name.replace("'", "''") + "'"
+
+
+def _unquote_tmdl_name(raw: str) -> str:
+    raw = raw.strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] == "'":
+        return raw[1:-1].replace("''", "'")
+    return raw
+
+
+def ensure_ref_table(model_tmdl_path: str | Path, table_name: str) -> bool:
+    """Ensure `model.tmdl` contains a `ref table <table_name>` line.
+
+    Inserts the line after the model's annotation block (alongside any existing
+    `ref table` lines, before the `ref cultureInfo` block) if absent. Idempotent.
+    Returns True if the file was modified.
+    """
+    path = Path(model_tmdl_path)
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    last_ref_table: int | None = None
+    first_ref_culture: int | None = None
+    for i, ln in enumerate(lines):
+        m = _REF_TABLE_RE.match(ln)
+        if m:
+            if _unquote_tmdl_name(m.group("name")) == table_name:
+                return False  # already referenced
+            last_ref_table = i
+        elif first_ref_culture is None and _REF_CULTURE_RE.match(ln):
+            first_ref_culture = i
+
+    new_line = f"ref table {quote_tmdl_name(table_name)}"
+    if last_ref_table is not None:
+        lines[last_ref_table + 1 : last_ref_table + 1] = ["", new_line]
+    elif first_ref_culture is not None:
+        lines[first_ref_culture:first_ref_culture] = [new_line, ""]
+    else:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.append(new_line)
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return True
+
+
+def remove_ref_table(model_tmdl_path: str | Path, table_name: str) -> bool:
+    """Remove the `ref table <table_name>` line from `model.tmdl` if present.
+
+    Also drops a blank line left adjacent to the removed reference so the ref
+    block stays single-blank-line separated. Idempotent. Returns True if the
+    file was modified.
+    """
+    path = Path(model_tmdl_path)
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    target = None
+    for i, ln in enumerate(lines):
+        m = _REF_TABLE_RE.match(ln)
+        if m and _unquote_tmdl_name(m.group("name")) == table_name:
+            target = i
+            break
+    if target is None:
+        return False
+
+    # Drop the ref line plus one adjacent blank line to avoid doubled blanks.
+    end = target + 1
+    if end < len(lines) and lines[end].strip() == "":
+        end += 1
+    elif target > 0 and lines[target - 1].strip() == "":
+        target -= 1
+    del lines[target:end]
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return True
+
+
+def ensure_ref_culture(model_tmdl_path: str | Path, culture: str = "en-US") -> bool:
+    """Ensure `model.tmdl` contains a `ref cultureInfo <culture>` line.
+
+    Appended after the ref-table block. Idempotent. Returns True if modified.
+    """
+    path = Path(model_tmdl_path)
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    for ln in lines:
+        m = _REF_CULTURE_RE.match(ln)
+        if m and _unquote_tmdl_name(m.group("name")) == culture:
+            return False
+
+    if lines and lines[-1].strip():
+        lines.append("")
+    lines.append(f"ref cultureInfo {culture}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return True

--- a/tests/unit/test_file_backend.py
+++ b/tests/unit/test_file_backend.py
@@ -223,6 +223,32 @@ class TestFileBackend:
         with pytest.raises(NotImplementedError):
             b.dax_query("EVALUATE Sales")
 
+    def test_structural_writes_fail_loud(self, tmdl_project):
+        # These are not persisted to TMDL, so they must raise rather than mutate
+        # in-memory state and report a success that never reaches disk.
+        b = FileBackend(path=tmdl_project)
+        with pytest.raises(NotImplementedError):
+            b.table_add("NewTable")
+        with pytest.raises(NotImplementedError):
+            b.table_delete("Sales")
+        with pytest.raises(NotImplementedError):
+            b.column_add("Sales", "Margin", "decimal")
+        with pytest.raises(NotImplementedError):
+            b.relationship_add("Sales", "DateKey", "Calendar", "DateKey")
+        with pytest.raises(NotImplementedError):
+            b.partition_add("Sales", "p2", "let Source = 1 in Source")
+        with pytest.raises(NotImplementedError):
+            b.role_add("Auditor", "Sales", "Sales[Region] = \"East\"")
+
+    def test_failed_table_add_leaves_disk_untouched(self, tmdl_project):
+        b = FileBackend(path=tmdl_project)
+        d = tmdl_project / "Demo.SemanticModel" / "definition"
+        before = (d / "model.tmdl").read_text(encoding="utf-8")
+        with pytest.raises(NotImplementedError):
+            b.table_add("Ghost")
+        assert (d / "model.tmdl").read_text(encoding="utf-8") == before
+        assert not (d / "tables" / "Ghost.tmdl").exists()
+
     def test_dax_validate_static(self, tmdl_project):
         b = FileBackend(path=tmdl_project)
         assert b.dax_validate("SUM(Sales[Revenue])")["valid"]
@@ -252,3 +278,46 @@ class TestFileBackendCli:
             cli, ["--backend", "file", "--path", str(tmp_path), "model", "tables"]
         )
         assert result.exit_code != 0
+
+    def test_source_scaffold_fails_loud_on_file_backend(self, tmdl_project):
+        # `source scaffold` materialises tables via backend.table_add — on the file
+        # backend that cannot persist, so it must fail loud, not report success
+        # while writing nothing to disk.
+        profile = tmdl_project / "profile.json"
+        profile.write_text(
+            json.dumps(
+                [
+                    {
+                        "tableName": "FactOrders",
+                        "rowCount": 1000,
+                        "columns": [
+                            {"name": "OrderKey", "dataType": "int64"},
+                            {"name": "Amount", "dataType": "decimal"},
+                        ],
+                    },
+                    {
+                        "tableName": "DimDate",
+                        "rowCount": 365,
+                        "columns": [{"name": "DateKey", "dataType": "int64"}],
+                    },
+                ]
+            ),
+            encoding="utf-8",
+        )
+        d = tmdl_project / "Demo.SemanticModel" / "definition"
+        model_before = (d / "model.tmdl").read_text(encoding="utf-8")
+        tables_before = {p.name for p in (d / "tables").glob("*.tmdl")}
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--backend", "file", "--path", str(tmdl_project),
+             "source", "scaffold", "--profile", str(profile)],
+        )
+
+        assert result.exit_code != 0
+        assert isinstance(result.exception, NotImplementedError)
+        assert "Scaffolded" not in result.output
+        # Nothing was written: model.tmdl and the tables folder are untouched.
+        assert (d / "model.tmdl").read_text(encoding="utf-8") == model_before
+        assert {p.name for p in (d / "tables").glob("*.tmdl")} == tables_before

--- a/tests/unit/test_pbir_features_batch2.py
+++ b/tests/unit/test_pbir_features_batch2.py
@@ -1,0 +1,240 @@
+"""Unit tests for the second batch of PBIR features:
+
+  - icon-set conditional formatting (default percent + custom absolute)
+  - between-bounds colour rules
+  - visual field rebinding
+  - report-level measures (reportExtensions.json)
+  - bookmark groups
+  - non-data element builders (textbox / button / navigators)
+  - pbi project new scaffold (openable PBIP)
+
+Synthetic PBIR GA project in tmp_path — runs anywhere, no Desktop needed.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pbi_cli.backends.pbir_backend import PbirBackend
+from pbi_cli.intelligence.visual_builder import (
+    AGG_SUM,
+    FieldDef,
+    VisualSpec,
+    build_card,
+    build_table,
+)
+
+
+@pytest.fixture()
+def backend(tmp_path) -> PbirBackend:
+    (tmp_path / "T.Report").mkdir()
+    return PbirBackend(str(tmp_path))
+
+
+def _fd(prop: str) -> FieldDef:
+    return FieldDef(entity="financials", property=prop, agg=AGG_SUM)
+
+
+def _add_table(b: PbirBackend, page: str, *props: str) -> str:
+    spec = VisualSpec("tableEx", build_table([_fd(p) for p in props]), 16, 16, 600, 300)
+    return b.visual_add(page, spec)["name"]
+
+
+def _add_card(b: PbirBackend, page: str) -> str:
+    spec = VisualSpec("card", build_card(_fd("Sales")), 0, 0, 200, 120)
+    return b.visual_add(page, spec)["name"]
+
+
+# ── Icon-set conditional formatting ───────────────────────────────────────────
+
+
+class TestIconCF:
+    def _setup(self, backend, page="IconP"):
+        backend.page_add(page)
+        return page, _add_table(backend, page, "Profit")
+
+    def test_default_three_band_percent(self, backend):
+        page, name = self._setup(backend)
+        assert backend.visual_format_icons(page, name, "financials", "Profit")
+        _, d = backend._ga_find_visual_json(page, name)
+        icon = d["visual"]["objects"]["values"][0]["properties"]["icon"]
+        assert icon["kind"] == "Icon"
+        cases = icon["value"]["expr"]["Conditional"]["Cases"]
+        assert [c["Value"]["Literal"]["Value"] for c in cases] == [
+            "'CircleHigh'", "'SignMedium'", "'SignLow'"
+        ]
+        top = cases[0]["Condition"]["Comparison"]
+        assert top["ComparisonKind"] == 2
+        assert top["Right"]["RangePercent"]["Percent"] == 0.67
+        assert "And" in cases[1]["Condition"]
+        assert top["Left"] == {"SelectRef": {"ExpressionName": "Sum(financials[Profit])"}}
+
+    def test_custom_absolute_icon_rules(self, backend):
+        page, name = self._setup(backend, "IconAbs")
+        backend.visual_format_icons(
+            page, name, "financials", "Profit",
+            rules=[(">=", 0, "ArrowUp"), ("<", 0, "ArrowDown")],
+        )
+        _, d = backend._ga_find_visual_json(page, name)
+        cases = d["visual"]["objects"]["values"][0]["properties"]["icon"][
+            "value"]["expr"]["Conditional"]["Cases"]
+        assert [c["Value"]["Literal"]["Value"] for c in cases] == ["'ArrowUp'", "'ArrowDown'"]
+        assert "Literal" in cases[0]["Condition"]["Comparison"]["Right"]
+
+    def test_icon_merges_with_existing_color(self, backend):
+        page, name = self._setup(backend, "IconMerge")
+        backend.visual_format_color_scale(page, name, "financials", "Profit", mid_color=None)
+        backend.visual_format_icons(page, name, "financials", "Profit")
+        _, d = backend._ga_find_visual_json(page, name)
+        values = d["visual"]["objects"]["values"]
+        assert len(values) == 1
+        assert {"backColor", "icon"} <= set(values[0]["properties"])
+
+
+# ── Between-bounds colour rules ───────────────────────────────────────────────
+
+
+class TestBetweenRules:
+    def test_between_builds_and_condition(self, backend):
+        backend.page_add("BetP")
+        name = _add_table(backend, "BetP", "Sales")
+        backend.visual_format_rules(
+            "BetP", name, "financials", "Sales",
+            [("between", 0, 1000, "#00FF00"), (">=", 1000, "#FF0000")],
+        )
+        _, d = backend._ga_find_visual_json("BetP", name)
+        cases = d["visual"]["objects"]["values"][0]["properties"][
+            "backColor"]["solid"]["color"]["expr"]["Conditional"]["Cases"]
+        andc = cases[0]["Condition"]["And"]
+        assert andc["Left"]["Comparison"]["ComparisonKind"] == 2
+        assert andc["Right"]["Comparison"]["ComparisonKind"] == 3
+        assert "Comparison" in cases[1]["Condition"]
+
+
+# ── Field rebinding ───────────────────────────────────────────────────────────
+
+
+class TestFieldRebind:
+    def test_replace_role_projection(self, backend):
+        backend.page_add("RbP")
+        name = _add_table(backend, "RbP", "Sales")
+        assert backend.visual_set_field("RbP", name, "Values", "financials", "Profit", agg=AGG_SUM)
+        _, d = backend._ga_find_visual_json("RbP", name)
+        projs = d["visual"]["query"]["queryState"]["Values"]["projections"]
+        assert len(projs) == 1
+        assert projs[0]["queryRef"] == "Sum(financials[Profit])"
+
+    def test_append_role_projection(self, backend):
+        backend.page_add("RbP2")
+        name = _add_table(backend, "RbP2", "Sales")
+        backend.visual_set_field(
+            "RbP2", name, "Values", "financials", "Profit", agg=AGG_SUM, replace=False
+        )
+        _, d = backend._ga_find_visual_json("RbP2", name)
+        refs = [p["queryRef"] for p in d["visual"]["query"]["queryState"]["Values"]["projections"]]
+        assert refs == ["Sum(financials[Sales])", "Sum(financials[Profit])"]
+
+    def test_missing_visual_returns_false(self, backend):
+        backend.page_add("RbP3")
+        assert backend.visual_set_field("RbP3", "nope", "Values", "financials", "Sales") is False
+
+
+# ── Report-level measures ─────────────────────────────────────────────────────
+
+
+class TestReportMeasures:
+    def test_add_and_list(self, backend):
+        backend.report_measure_add(
+            "financials", "Margin %",
+            "DIVIDE(SUM(financials[Profit]),SUM(financials[Sales]))", format_string="0.0%",
+        )
+        measures = backend.report_measure_list()
+        assert len(measures) == 1
+        assert measures[0]["name"] == "Margin %"
+        ext = json.loads((backend.report_dir / "definition" / "reportExtensions.json").read_text())
+        assert ext["name"] == "extension"
+        ent = ext["entities"][0]
+        assert ent["name"] == "financials" and "extends" not in ent
+        m = ent["measures"][0]
+        assert m["dataType"] == "Double"  # required by schema
+        assert m["formatString"] == "0.0%"
+
+    def test_replace_same_name(self, backend):
+        backend.report_measure_add("financials", "M", "1")
+        backend.report_measure_add("financials", "M", "2")
+        measures = backend.report_measure_list()
+        assert len(measures) == 1 and measures[0]["expression"] == "2"
+
+
+# ── Bookmark groups ───────────────────────────────────────────────────────────
+
+
+class TestBookmarkGroups:
+    def test_group_nests_members(self, backend):
+        backend.page_add("BGP")
+        _add_card(backend, "BGP")
+        backend.bookmark_add("A", page="BGP")
+        backend.bookmark_add("B", page="BGP")
+        result = backend.bookmark_group_add("Story", ["A", "B"])
+        meta = backend._ga_read_bookmarks_json()
+        group = next(it for it in meta["items"] if it.get("name") == result["name"])
+        assert group["displayName"] == "Story"
+        assert len(group["children"]) == 2
+        top_names = {it["name"] for it in meta["items"] if "children" not in it}
+        assert not (set(result["members"]) & top_names)
+
+
+# ── Non-data element builders ─────────────────────────────────────────────────
+
+
+class TestElements:
+    def test_textbox_with_text(self):
+        from pbi_cli.intelligence.visual_builder import build_textbox
+        body = build_textbox("Hello")
+        assert body["visualType"] == "textbox"
+        runs = body["objects"]["general"][0]["properties"]["paragraphs"][0]["textRuns"]
+        assert runs[0]["value"] == "Hello"
+
+    def test_action_button_shape(self):
+        from pbi_cli.intelligence.visual_builder import build_action_button
+        icon = build_action_button(shape="blank")["objects"]["icon"][0]
+        assert icon["properties"]["shapeType"]["expr"]["Literal"]["Value"] == "'blank'"
+        assert icon["selector"] == {"id": "default"}
+
+    def test_navigators(self):
+        from pbi_cli.intelligence.visual_builder import (
+            build_bookmark_navigator,
+            build_page_navigator,
+        )
+        assert build_page_navigator()["visualType"] == "pageNavigator"
+        assert build_bookmark_navigator()["visualType"] == "bookmarkNavigator"
+
+    def test_add_element_via_backend(self, backend):
+        from pbi_cli.intelligence.visual_builder import build_page_navigator
+        backend.page_add("ElP")
+        body = build_page_navigator()
+        spec = VisualSpec(visual_type=body["visualType"], visual_body=body,
+                          x=0, y=0, width=800, height=60)
+        backend.visual_add("ElP", spec)
+        assert "pageNavigator" in [v["visualType"] for v in backend.visual_list("ElP")]
+
+
+# ── project scaffold ──────────────────────────────────────────────────────────
+
+
+class TestProjectScaffold:
+    def test_creates_openable_structure(self, tmp_path):
+        from pbi_cli.project_scaffold import create_project
+        pbip = create_project(str(tmp_path), name="Acme", table="Financials")
+        assert pbip.exists()
+        root = tmp_path / "Acme"
+        model = (root / "Acme.SemanticModel" / "definition" / "model.tmdl").read_text()
+        assert "ref table Financials" in model
+        assert "ref cultureInfo en-US" in model
+        b = PbirBackend(str(pbip))
+        assert b.format == "pbir_ga"
+        assert "Overview" in [p["displayName"] for p in b.page_list()]
+        assert len(b.visual_list("Overview")) >= 4
+        assert (root / "Acme.Report" / "definition" / "version.json").exists()

--- a/tests/unit/test_pbir_groups_mobile.py
+++ b/tests/unit/test_pbir_groups_mobile.py
@@ -1,0 +1,109 @@
+"""Unit tests for visual container groups and mobile layout (PBIR GA).
+
+Shapes verified against Power BI Desktop output:
+  - group: a group-container visual.json with `visualGroup` + bounding box,
+    members tagged with top-level `parentGroupName`.
+  - mobile: a sibling mobile.json (visualContainerMobileState) with a position.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pbi_cli.backends.pbir_backend import PbirBackend
+from pbi_cli.intelligence.visual_builder import FieldDef, VisualSpec, build_card
+
+
+@pytest.fixture()
+def backend(tmp_path) -> PbirBackend:
+    (tmp_path / "T.Report").mkdir()
+    return PbirBackend(str(tmp_path))
+
+
+def _card(b: PbirBackend, page: str, x: int) -> str:
+    spec = VisualSpec("card", build_card(FieldDef(entity="F", property="Sales", agg=0)),
+                      x=x, y=10, width=100, height=80)
+    return b.visual_add(page, spec)["name"]
+
+
+class TestVisualGroups:
+    def test_group_creates_container_and_tags_members(self, backend):
+        backend.page_add("P")
+        a, c = _card(backend, "P", 0), _card(backend, "P", 120)
+        result = backend.visual_group_add("P", [a, c], display_name="KPIs")
+        # group container
+        _, g = backend._ga_find_visual_json("P", result["name"])
+        assert g["visualGroup"]["displayName"] == "KPIs"
+        assert g["visualGroup"]["groupMode"] == "ScaleMode"
+        # bounding box spans both cards (x 0..220)
+        assert g["position"]["x"] == 0 and g["position"]["width"] == 220
+        # members tagged
+        _, ma = backend._ga_find_visual_json("P", a)
+        _, mc = backend._ga_find_visual_json("P", c)
+        assert ma["parentGroupName"] == result["name"]
+        assert mc["parentGroupName"] == result["name"]
+
+    def test_group_listed_as_group_type(self, backend):
+        backend.page_add("P2")
+        a, c = _card(backend, "P2", 0), _card(backend, "P2", 120)
+        gid = backend.visual_group_add("P2", [a, c])["name"]
+        types = {v["name"]: v["visualType"] for v in backend.visual_list("P2")}
+        assert types[gid] == "group"
+
+    def test_group_requires_two_members(self, backend):
+        backend.page_add("P3")
+        a = _card(backend, "P3", 0)
+        with pytest.raises(ValueError):
+            backend.visual_group_add("P3", [a])
+
+    def test_group_missing_page_raises(self, backend):
+        with pytest.raises(ValueError):
+            backend.visual_group_add("Nope", ["a", "b"])
+
+
+class TestMobileLayout:
+    def test_mobile_writes_sibling_json(self, backend):
+        backend.page_add("M")
+        a = _card(backend, "M", 0)
+        assert backend.visual_set_mobile("M", a, x=10, y=20, width=140, height=120)
+        vj, _ = backend._ga_find_visual_json("M", a)
+        mobile = json.loads((vj.parent / "mobile.json").read_text(encoding="utf-8"))
+        assert mobile["position"] == {
+            "x": 10, "y": 20, "z": 1, "height": 120, "width": 140, "tabOrder": 0
+        }
+        assert "visualContainerMobileState" in mobile["$schema"]
+
+    def test_mobile_missing_visual_returns_false(self, backend):
+        backend.page_add("M2")
+        assert backend.visual_set_mobile("M2", "nope", 0, 0, 100, 100) is False
+
+
+class TestCliSurface:
+    @pytest.fixture()
+    def project(self, tmp_path):
+        from click.testing import CliRunner
+        (tmp_path / "C.Report").mkdir()
+        b = PbirBackend(str(tmp_path))
+        b.page_add("Pg")
+        a, c = _card(b, "Pg", 0), _card(b, "Pg", 120)
+        return CliRunner(), str(tmp_path), a, c
+
+    def _run(self, runner, *args):
+        from pbi_cli.cli import cli
+        return runner.invoke(cli, list(args))
+
+    def test_group_via_cli(self, project):
+        runner, pbip, a, c = project
+        r = self._run(runner, "visual", "group", "--pbip", pbip, "--page", "Pg",
+                      "--member", a, "--member", c, "--name", "KPIs")
+        assert r.exit_code == 0, r.output
+        assert "Grouped" in r.output
+
+    def test_mobile_via_cli(self, project):
+        runner, pbip, a, _ = project
+        r = self._run(runner, "visual", "mobile", "--pbip", pbip, "--page", "Pg",
+                      "--name", a, "--x", "0", "--y", "0", "--width", "320", "--height", "120")
+        assert r.exit_code == 0, r.output
+        assert "Mobile layout set" in r.output

--- a/tests/unit/test_pbir_new_features.py
+++ b/tests/unit/test_pbir_new_features.py
@@ -1,0 +1,397 @@
+"""Unit tests for the PBIR features added to close report-layer gaps:
+
+  - visual update/patch (position + title)
+  - rule-based / font-color conditional formatting
+  - bookmark state capture (sections + hidden visuals)
+  - page visual interactions
+  - slicer sync groups
+
+All tests build a synthetic PBIR GA project in tmp_path, so they run on any
+OS with no Power BI Desktop and no live .pbip fixture.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pbi_cli.backends.pbir_backend import PbirBackend
+from pbi_cli.intelligence.visual_builder import (
+    AGG_SUM,
+    FieldDef,
+    VisualSpec,
+    build_card,
+    build_slicer,
+    build_table,
+)
+
+
+@pytest.fixture()
+def backend(tmp_path) -> PbirBackend:
+    """A fresh, empty PBIR GA report backed by tmp_path."""
+    report_dir = tmp_path / "Test.Report"
+    report_dir.mkdir()
+    return PbirBackend(str(tmp_path))
+
+
+def _add_table(backend: PbirBackend, page: str, *fields: FieldDef, title: str = "") -> str:
+    spec = VisualSpec(
+        visual_type="tableEx",
+        visual_body=build_table(list(fields)),
+        x=16,
+        y=16,
+        width=600,
+        height=300,
+        title=title,
+    )
+    return backend.visual_add(page, spec)["name"]
+
+
+def _add_card(backend: PbirBackend, page: str) -> str:
+    spec = VisualSpec(
+        visual_type="card",
+        visual_body=build_card(FieldDef(entity="financials", property="Sales", agg=AGG_SUM)),
+        x=0,
+        y=0,
+        width=200,
+        height=120,
+    )
+    return backend.visual_add(page, spec)["name"]
+
+
+# ── Format detection ────────────────────────────────────────────────────────────
+
+
+def test_synthetic_report_is_ga(backend):
+    assert backend.format == "pbir_ga"
+
+
+# ── Visual update ─────────────────────────────────────────────────────────────
+
+
+class TestVisualUpdate:
+    def test_update_position(self, backend):
+        backend.page_add("P1")
+        name = _add_card(backend, "P1")
+        assert backend.visual_update("P1", name, x=120, y=240, width=480, height=200)
+        v = next(v for v in backend.visual_list("P1") if v["name"] == name)
+        assert (v["x"], v["y"], v["width"], v["height"]) == (120, 240, 480, 200)
+
+    def test_update_title_only_preserves_position(self, backend):
+        backend.page_add("P2")
+        name = _add_card(backend, "P2")
+        before = next(v for v in backend.visual_list("P2") if v["name"] == name)
+        assert backend.visual_update("P2", name, title="New Title")
+        _, data = backend._ga_find_visual_json("P2", name)
+        title = data["visual"]["visualContainerObjects"]["title"][0]["properties"]["text"]
+        assert title["expr"]["Literal"]["Value"] == "'New Title'"
+        after = next(v for v in backend.visual_list("P2") if v["name"] == name)
+        assert (after["x"], after["y"]) == (before["x"], before["y"])
+
+    def test_update_partial_leaves_other_fields(self, backend):
+        backend.page_add("P3")
+        name = _add_card(backend, "P3")
+        backend.visual_update("P3", name, x=99)
+        v = next(v for v in backend.visual_list("P3") if v["name"] == name)
+        assert v["x"] == 99
+        assert v["width"] == 200  # unchanged from add
+
+    def test_update_missing_visual_returns_false(self, backend):
+        backend.page_add("P4")
+        assert backend.visual_update("P4", "nope", x=1) is False
+
+
+# ── Conditional formatting: rules + font color ────────────────────────────────
+
+
+class TestFormatRules:
+    def _setup(self, backend, page="RuleP"):
+        backend.page_add(page)
+        name = _add_table(
+            backend, page, FieldDef(entity="financials", property="Profit", agg=AGG_SUM)
+        )
+        return page, name
+
+    def test_rules_backcolor_conditional_cases(self, backend):
+        page, name = self._setup(backend)
+        ok = backend.visual_format_rules(
+            page,
+            name,
+            "financials",
+            "Profit",
+            [(">=", 1000, "#00FF00"), ("<", 0, "#FF0000")],
+            target="backColor",
+        )
+        assert ok
+        _, data = backend._ga_find_visual_json(page, name)
+        entry = data["visual"]["objects"]["values"][0]
+        cases = entry["properties"]["backColor"]["solid"]["color"]["expr"]["Conditional"]["Cases"]
+        assert len(cases) == 2
+        # first rule: >= maps to ComparisonKind 2, literal '1000D'
+        cmp = cases[0]["Condition"]["Comparison"]
+        assert cmp["ComparisonKind"] == 2
+        assert cmp["Right"]["Literal"]["Value"] == "1000D"
+        assert cases[0]["Value"]["Literal"]["Value"] == "'#00FF00'"
+        # second rule: < maps to ComparisonKind 3
+        assert cases[1]["Condition"]["Comparison"]["ComparisonKind"] == 3
+
+    def test_font_color_uses_fontcolor_property(self, backend):
+        page, name = self._setup(backend, "FontP")
+        backend.visual_format_rules(
+            page, name, "financials", "Profit", [("<", 0, "#A4262C")], target="fontColor"
+        )
+        _, data = backend._ga_find_visual_json(page, name)
+        props = data["visual"]["objects"]["values"][0]["properties"]
+        assert "fontColor" in props
+        assert "backColor" not in props
+
+    def test_backcolor_and_fontcolor_merge_into_one_entry(self, backend):
+        page, name = self._setup(backend, "MergeP")
+        backend.visual_format_rules(
+            page, name, "financials", "Profit", [(">=", 0, "#00FF00")], target="backColor"
+        )
+        backend.visual_format_rules(
+            page, name, "financials", "Profit", [("<", 0, "#FF0000")], target="fontColor"
+        )
+        _, data = backend._ga_find_visual_json(page, name)
+        values = data["visual"]["objects"]["values"]
+        assert len(values) == 1, "same field should keep a single values entry"
+        props = values[0]["properties"]
+        assert "backColor" in props and "fontColor" in props
+
+    def test_selector_has_data_wildcard_and_metadata(self, backend):
+        page, name = self._setup(backend, "SelP")
+        backend.visual_format_rules(
+            page, name, "financials", "Profit", [(">=", 0, "#00FF00")]
+        )
+        _, data = backend._ga_find_visual_json(page, name)
+        sel = data["visual"]["objects"]["values"][0]["selector"]
+        assert sel["data"][0]["dataViewWildcard"]["matchingOption"] == 1
+        assert sel["metadata"] == "Sum(financials[Profit])"
+
+    def test_bad_operator_raises(self, backend):
+        page, name = self._setup(backend, "BadP")
+        with pytest.raises(ValueError):
+            backend.visual_format_rules(
+                page, name, "financials", "Profit", [("!!", 0, "#000000")]
+            )
+
+    def test_bad_target_raises(self, backend):
+        page, name = self._setup(backend, "BadT")
+        with pytest.raises(ValueError):
+            backend.visual_format_rules(
+                page, name, "financials", "Profit", [(">=", 0, "#000")], target="border"
+            )
+
+
+# ── Bookmark state capture ────────────────────────────────────────────────────
+
+
+class TestBookmarkCapture:
+    def test_capture_records_page_visuals(self, backend):
+        backend.page_add("BMPage")
+        v1 = _add_card(backend, "BMPage")
+        v2 = _add_table(
+            backend, "BMPage", FieldDef(entity="financials", property="Sales", agg=AGG_SUM)
+        )
+        result = backend.bookmark_add("Snapshot", page="BMPage")
+
+        bm_file = backend._ga_bookmarks_dir() / f"{result['name']}.bookmark.json"
+        data = json.loads(Path(bm_file).read_text(encoding="utf-8"))
+        sections = data["explorationState"]["sections"]
+        assert len(sections) == 1
+        page_state = next(iter(sections.values()))
+        vcs = page_state["visualContainers"]
+        assert set(vcs) == {v1, v2}
+        assert all("singleVisual" in vc for vc in vcs.values())
+
+    def test_hidden_visual_gets_display_mode_hidden(self, backend):
+        backend.page_add("HidePage")
+        v1 = _add_card(backend, "HidePage")
+        v2 = _add_card(backend, "HidePage")
+        result = backend.bookmark_add("HideOne", page="HidePage", hidden_visuals=[v2])
+
+        bm_file = backend._ga_bookmarks_dir() / f"{result['name']}.bookmark.json"
+        data = json.loads(Path(bm_file).read_text(encoding="utf-8"))
+        vcs = next(iter(data["explorationState"]["sections"].values()))["visualContainers"]
+        assert "display" not in vcs[v1]["singleVisual"]
+        assert vcs[v2]["singleVisual"]["display"]["mode"] == "hidden"
+        assert result["hiddenCount"] == 1
+
+    def test_target_visual_names_populated(self, backend):
+        backend.page_add("TgtPage")
+        _add_card(backend, "TgtPage")
+        result = backend.bookmark_add("Tgt", page="TgtPage")
+        assert len(result["options"]["targetVisualNames"]) == 1
+
+    def test_no_capture_writes_empty_sections(self, backend):
+        backend.page_add("EmptyPage")
+        _add_card(backend, "EmptyPage")
+        result = backend.bookmark_add("Skel", page="EmptyPage", capture=False)
+        bm_file = backend._ga_bookmarks_dir() / f"{result['name']}.bookmark.json"
+        data = json.loads(Path(bm_file).read_text(encoding="utf-8"))
+        assert data["explorationState"]["sections"] == {}
+
+
+# ── Visual interactions ───────────────────────────────────────────────────────
+
+
+class TestVisualInteractions:
+    def test_set_interaction_writes_page_json(self, backend):
+        backend.page_add("IxPage")
+        src = _add_card(backend, "IxPage")
+        tgt = _add_card(backend, "IxPage")
+        backend.set_visual_interaction("IxPage", src, tgt, "NoFilter")
+
+        page_dir = backend._ga_find_page_dir("IxPage")
+        data = json.loads((page_dir / "page.json").read_text(encoding="utf-8"))
+        ix = data["visualInteractions"]
+        assert ix == [{"source": src, "target": tgt, "type": "NoFilter"}]
+
+    def test_set_interaction_replaces_same_pair(self, backend):
+        backend.page_add("IxPage2")
+        src = _add_card(backend, "IxPage2")
+        tgt = _add_card(backend, "IxPage2")
+        backend.set_visual_interaction("IxPage2", src, tgt, "NoFilter")
+        backend.set_visual_interaction("IxPage2", src, tgt, "HighlightFilter")
+        page_dir = backend._ga_find_page_dir("IxPage2")
+        data = json.loads((page_dir / "page.json").read_text(encoding="utf-8"))
+        assert len(data["visualInteractions"]) == 1
+        assert data["visualInteractions"][0]["type"] == "HighlightFilter"
+
+    def test_bad_type_raises(self, backend):
+        backend.page_add("IxBad")
+        a = _add_card(backend, "IxBad")
+        b = _add_card(backend, "IxBad")
+        with pytest.raises(ValueError):
+            backend.set_visual_interaction("IxBad", a, b, "Bogus")
+
+    def test_missing_page_raises(self, backend):
+        with pytest.raises(ValueError):
+            backend.set_visual_interaction("NoPage", "a", "b", "NoFilter")
+
+
+# ── Slicer sync ───────────────────────────────────────────────────────────────
+
+
+class TestSlicerSync:
+    def test_sync_writes_sync_group(self, backend):
+        backend.page_add("SyncPage")
+        spec = VisualSpec(
+            visual_type="slicer",
+            visual_body=build_slicer(FieldDef(entity="financials", property="Country", agg=None)),
+            x=0,
+            y=0,
+            width=200,
+            height=300,
+        )
+        name = backend.visual_add("SyncPage", spec)["name"]
+        assert backend.set_slicer_sync("SyncPage", name, "Region", filter_changes=False)
+        _, data = backend._ga_find_visual_json("SyncPage", name)
+        sg = data["visual"]["syncGroup"]
+        assert sg["groupName"] == "Region"
+        assert sg["fieldChanges"] is True
+        assert sg["filterChanges"] is False
+
+    def test_sync_missing_visual_returns_false(self, backend):
+        backend.page_add("SyncMiss")
+        assert backend.set_slicer_sync("SyncMiss", "nope", "G") is False
+
+
+# ── CLI surface ───────────────────────────────────────────────────────────────
+
+
+class TestCliSurface:
+    """Exercise the click commands end-to-end against a synthetic project."""
+
+    @pytest.fixture()
+    def project(self, tmp_path):
+        from click.testing import CliRunner
+
+        report_dir = tmp_path / "Cli.Report"
+        report_dir.mkdir()
+        b = PbirBackend(str(tmp_path))
+        b.page_add("Sales")
+        name = _add_table(
+            b, "Sales", FieldDef(entity="financials", property="Profit", agg=AGG_SUM)
+        )
+        # second card to act as interaction target
+        card = _add_card(b, "Sales")
+        return CliRunner(), str(tmp_path), name, card
+
+    def _run(self, runner, *args):
+        from pbi_cli.cli import cli
+
+        return runner.invoke(cli, list(args))
+
+    def test_update_requires_a_property(self, project):
+        runner, pbip, name, _ = project
+        r = self._run(runner, "visual", "update", "--pbip", pbip, "--page", "Sales", "--name", name)
+        assert r.exit_code != 0
+        assert "at least one" in r.output.lower()
+
+    def test_update_title_and_position(self, project):
+        runner, pbip, name, _ = project
+        r = self._run(
+            runner, "visual", "update", "--pbip", pbip, "--page", "Sales",
+            "--name", name, "--x", "50", "--title", "Revenue",
+        )
+        assert r.exit_code == 0, r.output
+        assert "Updated" in r.output
+
+    def test_format_rules_via_cli(self, project):
+        runner, pbip, name, _ = project
+        r = self._run(
+            runner, "visual", "format", "--pbip", pbip, "--page", "Sales",
+            "--visual", name, "--type", "rules", "--target", "text",
+            "--table", "financials", "--measure", "Profit",
+            "--rule", ">=:0:#107C10", "--rule", "<:0:#A4262C",
+        )
+        assert r.exit_code == 0, r.output
+        assert "rules" in r.output.lower()
+
+    def test_format_rules_requires_rule(self, project):
+        runner, pbip, name, _ = project
+        r = self._run(
+            runner, "visual", "format", "--pbip", pbip, "--page", "Sales",
+            "--visual", name, "--type", "rules",
+            "--table", "financials", "--measure", "Profit",
+        )
+        assert r.exit_code != 0
+
+    def test_format_rule_bad_format(self, project):
+        runner, pbip, name, _ = project
+        r = self._run(
+            runner, "visual", "format", "--pbip", pbip, "--page", "Sales",
+            "--visual", name, "--type", "rules",
+            "--table", "financials", "--measure", "Profit", "--rule", "garbage",
+        )
+        assert r.exit_code != 0
+
+    def test_interaction_via_cli(self, project):
+        runner, pbip, name, card = project
+        r = self._run(
+            runner, "visual", "interaction", "--pbip", pbip, "--page", "Sales",
+            "--source", name, "--target", card, "--type", "NoFilter",
+        )
+        assert r.exit_code == 0, r.output
+        assert "Interaction set" in r.output
+
+    def test_sync_slicer_via_cli(self, project):
+        runner, pbip, name, _ = project
+        r = self._run(
+            runner, "visual", "sync-slicer", "--pbip", pbip, "--page", "Sales",
+            "--name", name, "--group", "Region",
+        )
+        assert r.exit_code == 0, r.output
+
+    def test_bookmark_add_hidden_via_cli(self, project):
+        runner, pbip, name, card = project
+        r = self._run(
+            runner, "report", "bookmark-add", "--pbip", pbip, "--name", "HideBM",
+            "--page", "Sales", "--hidden-visual", card,
+        )
+        assert r.exit_code == 0, r.output
+        assert "Captured" in r.output

--- a/tests/unit/test_tmdl_util.py
+++ b/tests/unit/test_tmdl_util.py
@@ -1,0 +1,127 @@
+"""Unit tests for tmdl_util — keeping model.tmdl `ref table` / `ref cultureInfo`
+lines in sync.
+
+TMDL does not auto-discover table files, so a table .tmdl with no matching
+`ref table` line loads silently missing in Desktop. These tests pin the helper
+behaviour and assert the canonical model.tmdl shape used by project_scaffold.
+"""
+
+from __future__ import annotations
+
+from pbi_cli.tmdl_util import (
+    ensure_ref_culture,
+    ensure_ref_table,
+    quote_tmdl_name,
+    remove_ref_table,
+)
+
+# Canonical model.tmdl base (annotation block, no ref lines yet) — mirrors the
+# known-good shape written by project_scaffold._write_model.
+_MODEL_BASE = (
+    "model Model\n"
+    "\tculture: en-US\n"
+    "\tdefaultPowerBIDataSourceVersion: powerBI_V3\n"
+    "\tdiscourageImplicitMeasures\n"
+    "\tsourceQueryCulture: en-US\n"
+    "\tdataAccessOptions\n"
+    "\t\tlegacyRedirects\n"
+    "\t\treturnErrorValuesAsNull\n\n"
+    '\tannotation PBI_QueryOrder = ["Financials"]\n\n'
+    '\tannotation PBI_ProTooling = ["DevMode"]\n'
+)
+
+
+def _model(tmp_path, text=_MODEL_BASE):
+    p = tmp_path / "model.tmdl"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+class TestQuote:
+    def test_bare_identifier_unquoted(self):
+        assert quote_tmdl_name("Financials") == "Financials"
+        assert quote_tmdl_name("Date_Table") == "Date_Table"
+
+    def test_spaces_quoted(self):
+        assert quote_tmdl_name("Units Sold") == "'Units Sold'"
+
+    def test_embedded_quote_doubled(self):
+        assert quote_tmdl_name("O'Brien") == "'O''Brien'"
+
+
+class TestEnsureRefTable:
+    def test_adds_when_absent(self, tmp_path):
+        m = _model(tmp_path)
+        assert ensure_ref_table(m, "Financials") is True
+        assert "ref table Financials" in m.read_text(encoding="utf-8")
+
+    def test_idempotent(self, tmp_path):
+        m = _model(tmp_path)
+        ensure_ref_table(m, "Financials")
+        before = m.read_text(encoding="utf-8")
+        assert ensure_ref_table(m, "Financials") is False
+        assert m.read_text(encoding="utf-8") == before
+        assert before.count("ref table Financials") == 1
+
+    def test_quotes_name_with_spaces(self, tmp_path):
+        m = _model(tmp_path)
+        ensure_ref_table(m, "Sales Detail")
+        assert "ref table 'Sales Detail'" in m.read_text(encoding="utf-8")
+        # And recognises the quoted form on the second pass.
+        assert ensure_ref_table(m, "Sales Detail") is False
+
+    def test_second_table_joins_block_before_culture(self, tmp_path):
+        m = _model(tmp_path)
+        ensure_ref_table(m, "Financials")
+        ensure_ref_culture(m, "en-US")
+        ensure_ref_table(m, "Date")
+        text = m.read_text(encoding="utf-8")
+        # Both tables referenced, culture line stays last.
+        assert text.index("ref table Financials") < text.index("ref table Date")
+        assert text.index("ref table Date") < text.index("ref cultureInfo en-US")
+
+    def test_matches_scaffold_output(self, tmp_path):
+        """ensure_ref_* on the base must reproduce the canonical scaffold bytes."""
+        m = _model(tmp_path)
+        ensure_ref_table(m, "Financials")
+        ensure_ref_culture(m, "en-US")
+        assert m.read_text(encoding="utf-8") == (
+            _MODEL_BASE + "\nref table Financials\n\nref cultureInfo en-US\n"
+        )
+
+
+class TestRemoveRefTable:
+    def test_removes_line(self, tmp_path):
+        m = _model(tmp_path)
+        ensure_ref_table(m, "Financials")
+        ensure_ref_culture(m, "en-US")
+        assert remove_ref_table(m, "Financials") is True
+        text = m.read_text(encoding="utf-8")
+        assert "ref table Financials" not in text
+        # Culture reference survives and no doubled blank lines are left.
+        assert "ref cultureInfo en-US" in text
+        assert "\n\n\n" not in text
+
+    def test_idempotent_when_absent(self, tmp_path):
+        m = _model(tmp_path)
+        assert remove_ref_table(m, "Nope") is False
+
+    def test_round_trip_one_of_two(self, tmp_path):
+        m = _model(tmp_path)
+        ensure_ref_table(m, "Financials")
+        ensure_ref_table(m, "Date")
+        ensure_ref_culture(m, "en-US")
+        remove_ref_table(m, "Financials")
+        text = m.read_text(encoding="utf-8")
+        assert "ref table Financials" not in text
+        assert "ref table Date" in text
+        assert "ref cultureInfo en-US" in text
+        assert "\n\n\n" not in text
+
+
+class TestEnsureRefCulture:
+    def test_adds_and_idempotent(self, tmp_path):
+        m = _model(tmp_path)
+        assert ensure_ref_culture(m, "en-US") is True
+        assert ensure_ref_culture(m, "en-US") is False
+        assert m.read_text(encoding="utf-8").count("ref cultureInfo en-US") == 1


### PR DESCRIPTION
## Summary
Bundles the in-flight PBIR report-layer work plus this session's file-backend correctness fix and shared TMDL `ref table` helper.

### This session's work (the focus)
- **File backend fails loud on unpersisted structural writes.** `FileBackend` only persists *measure* edits to TMDL. `table_add`/`table_delete`, `column_add`/`column_delete`, `relationship_add`, `hierarchy_*`, `calc_group_add`, `calc_item_*`, `role_*`, and `partition_*` previously mutated only in-memory state (lost at process exit) while the command reported success — e.g. `--backend file source scaffold` printed *"Scaffolded N tables"* and wrote nothing. They now raise `NotImplementedError` pointing at the desktop/xmla backends or `pbi project new`. The `fabric` backend inherits this until structural push-back lands.
- **New `tmdl_util`** — idempotent `ensure_ref_table` / `remove_ref_table` / `ensure_ref_culture` / `quote_tmdl_name`. TMDL does **not** auto-discover table files: `model.tmdl` must carry a `ref table <name>` line per table or Desktop loads it silently missing. `project_scaffold` refactored to use these (output byte-identical).

### Also included (pre-existing in-flight work)
PBIR batch 2-3: visual groups + mobile layout, icon/rule conditional formatting, `set-field` rebinding, report-level measures, bookmark groups, non-data elements, and the openable `pbi project new` scaffold (`project_scaffold.py`, `project_cmd.py`).

## Testing
- `python -m pytest tests/unit -q` → **960 passed**
- `ruff check src/pbi_cli/` → clean
- `mypy src/pbi_cli/` → clean (86 files)

## Follow-up
Full structural TMDL persistence in `FileBackend` (replacing the fail-loud guards with real writes) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)