### PR TITLE
feat(pbir): harden report layer — schema registry, correct filters, generic formatting, atomic rebind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — PBIR hardening: schema registry, correct filters, generic formatting, atomic rebind
+- **Schema-version registry** (`pbi_cli.backends.pbir_schemas`) — single source of
+  truth for every PBIR `$schema` URL, populated from the latest *published* versions
+  in [microsoft/json-schemas](https://github.com/microsoft/json-schemas/tree/main/fabric/item/report).
+  `pbir_backend`, `visual_builder` and `project_scaffold` now resolve schema URLs
+  through it, so a Microsoft version bump is a one-line change. Bumped to the current
+  published versions (visualContainer `2.7.0`→`2.9.0`, report `3.2.0`→`3.3.0`,
+  pagesMetadata `1.0.0`→`1.1.0`) and fixed `visualContainerMobileState` which pointed
+  at a non-existent `2.5.0` (now the published `2.4.0`). New
+  `scripts/check_pbir_schemas.py` flags drift against the live repo.
+- **Filters rewritten to the real schema.** `pbi filter` now writes a valid
+  `filterConfig` with proper `FilterContainer` + `FilterDefinition`
+  (`Version`/`From`/`Where`) bodies. The previous flat
+  `{operator, timeUnitsCount, values}` shape matched no published schema and was a
+  blocking error in Desktop. Generated `FilterContainer`s are validated in CI
+  against Microsoft's vendored filterConfiguration `1.3.0` schema. Note: an
+  *embedded* `filterConfig` must NOT carry a `$schema` key (Desktop blocks it,
+  even though the standalone schema marks it required) — verified live in Desktop. New `--exclude` on `add-value`, new `add-advanced`
+  (one/two numeric comparisons joined by And/Or), `--locked`/`--hidden` flags.
+  **Breaking:** `pbi filter add-topn` removed — a page-level TopN with an order-by
+  measure has no representation in the `FilterDefinition` schema (which allows only
+  `Version`/`From`/`Where`); TopN belongs at the visual level (future work).
+- `pbi visual set-format` — **generic formatting writer** for any formatting-object
+  property (data labels, legend position, background colour, axis titles, …), not
+  just conditional formatting. Targets `objects` or, with `--container`,
+  `visualContainerObjects`; merges repeated calls into one entry.
+- `pbi visual rebind` — **atomic multi-role rebind.** Rewrites several role slots in
+  one write (and optionally clears unlisted roles), preserving position, title and
+  formatting — the safe in-place equivalent of delete + re-add. Builds all
+  projections before writing so a bad binding never half-rewrites a visual.
+
 ### Changed — file backend: structural writes fail loud; shared `ref table` helper
 - `FileBackend` no longer silently no-ops structural writes it can't persist. Only
   measure edits are written back to TMDL; `table_add`/`table_delete`, `column_add`/

--- a/docs/adr/003-pbir-report-layer.md
+++ b/docs/adr/003-pbir-report-layer.md
@@ -32,3 +32,30 @@ Add a `PbirBackend` class that reads and writes PBIR JSON report files directly,
 - `pbi report`, `pbi visual`, `pbi layout`, `pbi theme` commands use the PBIR backend.
 - PBIR backend is file-based; it requires a `.pbip` folder path, not a network connection.
 - Tests for PBIR backend use fixture JSON files (no Power BI Desktop required).
+
+## Update (2026-06-21): schema drift, filters, and limitations
+
+Operating experience surfaced three things worth recording:
+
+1. **Schema-version drift is the main maintenance risk.** PBIR bumps each file's
+   schema version independently and frequently. Schema URLs are now centralised in
+   `pbi_cli.backends.pbir_schemas`, pinned to the latest *published* versions in
+   [microsoft/json-schemas](https://github.com/microsoft/json-schemas/tree/main/fabric/item/report)
+   and checked by `scripts/check_pbir_schemas.py`. A version bump is a one-line edit.
+
+2. **Filters must follow the published `filterConfiguration` schema.** Filters live
+   on a page/report/visual under `filterConfig`, as `FilterContainer`s whose `filter`
+   is a `FilterDefinition` (`Version`/`From`/`Where`) — a partial semantic query.
+   Generated filters are validated in CI against Microsoft's vendored schemas
+   (`tests/fixtures/pbir_schemas/`). One Desktop-only quirk, found by live testing:
+   an *embedded* `filterConfig` must omit the `$schema` key (Desktop treats it as a
+   disallowed additional property and blocks the open), even though the standalone
+   filterConfiguration schema marks `$schema` required. `$schema` belongs only on
+   standalone definition files, never on `$ref`-inlined objects. Filter *types* without a representation in
+   `FilterDefinition` (e.g. a page-level TopN with an order-by measure) are out of
+   scope and are not emitted rather than producing invalid JSON.
+
+3. **No live preview remains a deliberate limitation, not a gap.** PBIR is a save
+   format, not a live API: writing JSON cannot refresh an open Desktop instance, and
+   PBIR is not exposed over XMLA. Every write command therefore prints a "reload in
+   Desktop" hint, and `pbi visual screenshot` (Playwright) covers CI verification.

--- a/scripts/check_pbir_schemas.py
+++ b/scripts/check_pbir_schemas.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+"""Detect PBIR schema-version drift.
+
+Compares the versions pinned in ``pbi_cli.backends.pbir_schemas`` against the
+latest versions published in the official Microsoft schema repository:
+
+    https://github.com/microsoft/json-schemas/tree/main/fabric/item/report/definition
+
+Usage::
+
+    python scripts/check_pbir_schemas.py            # human-readable report
+    python scripts/check_pbir_schemas.py --strict   # exit 1 if any pin is stale
+
+Requires the GitHub CLI (``gh``) to be installed and authenticated, or a
+``GITHUB_TOKEN`` in the environment. Network access is required; this is a
+maintenance helper, not part of the test suite.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+from pbi_cli.backends import pbir_schemas as schemas
+
+_REPO = "microsoft/json-schemas"
+_PATH = "fabric/item/report/definition"
+
+
+def _semver_key(v: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(p) for p in v.split("."))
+    except ValueError:
+        return (0,)
+
+
+def _list_versions(name: str) -> list[str]:
+    out = subprocess.check_output(
+        ["gh", "api", f"repos/{_REPO}/contents/{_PATH}/{name}", "--jq", "[.[].name]"],
+        text=True,
+    )
+    names = json.loads(out)
+    return sorted((n for n in names if n[0].isdigit()), key=_semver_key)
+
+
+def main(argv: list[str]) -> int:
+    strict = "--strict" in argv
+    drift = False
+    print(f"{'schema':<32} {'pinned':<10} {'latest':<10} status")
+    print("-" * 64)
+    for name, pinned in sorted(schemas.DEFINITION_SCHEMA_VERSIONS.items()):
+        try:
+            versions = _list_versions(name)
+        except Exception as exc:  # noqa: BLE001 - reporting tool
+            print(f"{name:<32} {pinned:<10} {'?':<10} ERROR: {exc}")
+            drift = True
+            continue
+        latest = versions[-1] if versions else "?"
+        status = "ok" if latest == pinned else "STALE"
+        if status == "STALE":
+            drift = True
+        print(f"{name:<32} {pinned:<10} {latest:<10} {status}")
+
+    if drift and strict:
+        print("\nSchema drift detected. Update pbir_schemas.DEFINITION_SCHEMA_VERSIONS.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/pbi_cli/backends/pbir_backend.py
+++ b/src/pbi_cli/backends/pbir_backend.py
@@ -14,6 +14,8 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from pbi_cli.backends import pbir_schemas as _schemas
+
 
 def _slug(name: str) -> str:
     """Sanitise a display name for use as a directory name."""
@@ -151,10 +153,7 @@ class PbirBackend:
     def _ga_write_pages_json(self, data: dict[str, Any]) -> None:
         pj = self._ga_pages_dir() / "pages.json"
         if "$schema" not in data:
-            data["$schema"] = (
-                "https://developer.microsoft.com/json-schemas/fabric/item/"
-                "report/definition/pagesMetadata/1.0.0/schema.json"
-            )
+            data["$schema"] = _schemas.definition_schema("pagesMetadata")
         pj.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
     def _ga_page_list(self) -> list[dict[str, Any]]:
@@ -192,10 +191,7 @@ class PbirBackend:
         (page_dir / "visuals").mkdir(exist_ok=True)
 
         page_json: dict[str, Any] = {
-            "$schema": (
-                "https://developer.microsoft.com/json-schemas/fabric/item/"
-                "report/definition/page/2.1.0/schema.json"
-            ),
+            "$schema": _schemas.definition_schema("page"),
             "name": page_id,
             "displayName": display_name,
             "displayOption": "FitToPage",
@@ -316,18 +312,11 @@ class PbirBackend:
     def _write_ga_report_json(self) -> None:
         assert self._report_dir
         report_json = {
-            "$schema": (
-                "https://developer.microsoft.com/json-schemas/fabric/item/"
-                "report/definition/report/3.2.0/schema.json"
-            ),
+            "$schema": _schemas.definition_schema("report"),
             "themeCollection": {
                 "baseTheme": {
                     "name": "Fluent2-CY26SU04",
-                    "reportVersionAtImport": {
-                        "visual": "2.8.0",
-                        "report": "3.2.0",
-                        "page": "2.3.1",
-                    },
+                    "reportVersionAtImport": dict(_schemas.REPORT_VERSION_AT_IMPORT),
                     "type": "SharedResources",
                 }
             },
@@ -461,10 +450,7 @@ class PbirBackend:
 
     def _ga_write_bookmarks_json(self, data: dict[str, Any]) -> None:
         bj = self._ga_bookmarks_dir() / "bookmarks.json"
-        data["$schema"] = (
-            "https://developer.microsoft.com/json-schemas/fabric/item/"
-            "report/definition/bookmarksMetadata/1.0.0/schema.json"
-        )
+        data["$schema"] = _schemas.definition_schema("bookmarksMetadata")
         bj.write_text(json.dumps(data, indent=2), encoding="utf-8")
 
     def bookmark_list(self) -> list[dict[str, Any]]:
@@ -540,10 +526,7 @@ class PbirBackend:
                 sections[active_section] = {"visualContainers": visual_containers}
 
         bm: dict[str, Any] = {
-            "$schema": (
-                "https://developer.microsoft.com/json-schemas/fabric/item/"
-                "report/definition/bookmark/2.1.0/schema.json"
-            ),
+            "$schema": _schemas.definition_schema("bookmark"),
             "displayName": display_name,
             "name": bm_id,
             "options": {"targetVisualNames": target_visuals},
@@ -1254,6 +1237,141 @@ class PbirBackend:
         vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
         return True
 
+    def visual_rebind(
+        self,
+        page: str,
+        visual_name: str,
+        bindings: dict[str, list[Any]],
+        *,
+        clear_unlisted: bool = False,
+    ) -> bool:
+        """Atomically rebind several role slots of a visual in one write.
+
+        ``bindings`` maps a role name (Category, Y, Values, Rows, Columns, ...) to
+        a list of ``FieldDef``. Each listed role is fully replaced with its given
+        fields. With ``clear_unlisted=True`` every role *not* in ``bindings`` is
+        removed too, so the visual ends up bound to exactly ``bindings`` — the
+        in-place equivalent of delete + re-add, but preserving position, title and
+        formatting. PBIR GA only. Returns True if the visual was found+updated.
+
+        The visual file is only written if every field is valid, so a bad binding
+        never leaves the visual half-rewritten.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Field rebinding requires PBIR GA format (definition/ folder).")
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return False
+        vj, data = found
+
+        # Build all projections first; any failure aborts before writing.
+        new_state: dict[str, list[dict[str, Any]]] = {}
+        for role, fields in bindings.items():
+            if not role:
+                raise ValueError("role names must be non-empty")
+            new_state[role] = [f.to_projection() for f in fields]
+
+        query = data.setdefault("visual", {}).setdefault("query", {})
+        query_state = query.setdefault("queryState", {})
+        if clear_unlisted:
+            query_state.clear()
+        for role, projections in new_state.items():
+            query_state[role] = {"projections": projections}
+
+        vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return True
+
+    # ── Generic visual formatting (formatting object definitions) ──────────────
+    # Beyond the bespoke conditional-formatting writers above, this writes any
+    # formatting-object property Desktop supports. Structure (per the
+    # formattingObjectDefinitions schema): visual.objects[<object>] is a list of
+    # { selector?, properties } entries; each property value is an expression such
+    # as a Literal, or a solid colour wrapper for colour properties.
+
+    @staticmethod
+    def _format_value_expr(value: Any, value_type: str) -> dict[str, Any]:
+        """Build the expression for a formatting property value.
+
+        value_type: 'text' | 'number' | 'bool' | 'color' | 'auto'. 'auto' infers
+        from the Python type (bool/int/float/str; '#RRGGBB' strings → color).
+        """
+        vt = value_type
+        if vt == "auto":
+            if isinstance(value, bool):
+                vt = "bool"
+            elif isinstance(value, (int, float)):
+                vt = "number"
+            elif isinstance(value, str) and re.fullmatch(r"#[0-9A-Fa-f]{6,8}", value):
+                vt = "color"
+            else:
+                vt = "text"
+
+        if vt == "bool":
+            literal = {"expr": {"Literal": {"Value": "true" if value else "false"}}}
+        elif vt == "number":
+            num = int(value) if isinstance(value, float) and value.is_integer() else value
+            literal = {"expr": {"Literal": {"Value": f"{num}D"}}}
+        elif vt == "color":
+            return {"solid": {"color": {"expr": {"Literal": {"Value": f"'{value}'"}}}}}
+        else:  # text
+            literal = {"expr": {"Literal": {"Value": f"'{value}'"}}}
+        return literal
+
+    def visual_set_format(
+        self,
+        page: str,
+        visual_name: str,
+        object_name: str,
+        property_name: str,
+        value: Any,
+        *,
+        value_type: str = "auto",
+        selector: dict[str, Any] | None = None,
+        container_level: bool = False,
+    ) -> bool:
+        """Set an arbitrary formatting-object property on a visual.
+
+        Examples of (object_name, property_name): ('title','text'),
+        ('title','show'), ('background','color'), ('legend','position'),
+        ('dataLabels','show'), ('categoryAxis','titleText').
+
+        ``container_level=True`` targets ``visualContainerObjects`` (chrome shared
+        by all visual types: title, background, border, visualHeader) instead of
+        the type-specific ``objects``. Entries are merged by ``selector`` so
+        repeated calls accumulate into one entry. PBIR GA only. Returns True if
+        the visual was found and updated.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Generic formatting requires PBIR GA format (definition/ folder).")
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return False
+        vj, data = found
+
+        visual = data.setdefault("visual", {})
+        bucket_key = "visualContainerObjects" if container_level else "objects"
+        bucket = visual.setdefault(bucket_key, {})
+        entries: list[dict[str, Any]] = bucket.setdefault(object_name, [])
+
+        prop_expr = self._format_value_expr(value, value_type)
+
+        # Merge into an entry with a matching selector (None == whole-visual).
+        target = next(
+            (e for e in entries if e.get("selector") == selector),
+            None,
+        )
+        if target is None:
+            target = {"properties": {}}
+            if selector is not None:
+                target["selector"] = selector
+            entries.append(target)
+        target.setdefault("properties", {})[property_name] = prop_expr
+
+        vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return True
+
     # ── Report-level measures (reportExtensions.json) ──────────────────────────
 
     def _report_extension_path(self) -> Path:
@@ -1284,10 +1402,7 @@ class PbirBackend:
             ext = json.loads(path.read_text(encoding="utf-8"))
         else:
             ext = {
-                "$schema": (
-                    "https://developer.microsoft.com/json-schemas/fabric/item/"
-                    "report/definition/reportExtension/1.0.0/schema.json"
-                ),
+                "$schema": _schemas.definition_schema("reportExtension"),
                 "name": "extension",
                 "entities": [],
             }
@@ -1496,10 +1611,7 @@ class PbirBackend:
     # ── Mobile layout ──────────────────────────────────────────────────────────
     # Each visual's mobile position is a sibling mobile.json (visualContainerMobileState).
 
-    MOBILE_STATE_SCHEMA = (
-        "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/"
-        "visualContainerMobileState/2.5.0/schema.json"
-    )
+    MOBILE_STATE_SCHEMA = _schemas.definition_schema("visualContainerMobileState")
 
     def visual_set_mobile(
         self,

--- a/src/pbi_cli/backends/pbir_schemas.py
+++ b/src/pbi_cli/backends/pbir_schemas.py
@@ -1,0 +1,86 @@
+"""Single source of truth for PBIR (Power BI enhanced report format) JSON schema
+versions.
+
+PBIR is a young, evolving format: Microsoft bumps the schema version of each file
+type independently (visualContainer is already at 2.9.0, report at 3.3.0, ...).
+Hard-coding those URLs across the codebase means a Microsoft version bump turns
+into a multi-file hunt. Centralising them here makes a bump a one-line change.
+
+The version numbers below are the latest *published* versions in the official
+schema repository:
+
+    https://github.com/microsoft/json-schemas/tree/main/fabric/item/report
+
+To refresh them, run ``scripts/check_pbir_schemas.py`` (compares this table with
+the live repo) or re-list the repo with::
+
+    gh api repos/microsoft/json-schemas/contents/fabric/item/report/definition \\
+        --jq '.[] | select(.type=="dir") | .name'
+
+Schema URLs are publicly resolvable and double as IntelliSense/validation hints
+in editors like VS Code, so writing the correct, current URL matters.
+"""
+
+from __future__ import annotations
+
+_BASE = "https://developer.microsoft.com/json-schemas/fabric/item/report"
+
+# ── Schemas under report/definition/ ────────────────────────────────────────────
+# name -> latest published version. Keep alphabetical; verified against the repo.
+DEFINITION_SCHEMA_VERSIONS: dict[str, str] = {
+    "bookmark": "2.1.0",
+    "bookmarksMetadata": "1.0.0",
+    "filterConfiguration": "1.3.0",
+    "formattingObjectDefinitions": "1.5.0",
+    "page": "2.1.0",
+    "pagesMetadata": "1.1.0",
+    "report": "3.3.0",
+    "reportExtension": "1.0.0",
+    "semanticQuery": "1.4.0",
+    "versionMetadata": "1.0.0",
+    "visualConfiguration": "2.3.0",
+    "visualContainer": "2.9.0",
+    "visualContainerMobileState": "2.4.0",
+}
+
+# ── Schemas directly under report/ (not the definition/ folder) ─────────────────
+_ITEM_SCHEMA_VERSIONS: dict[str, str] = {
+    "definitionProperties": "2.0.0",  # the definition.pbir file
+}
+
+# ``reportVersionAtImport`` records the Power BI *application* feature versions a
+# report was authored against — distinct from the JSON-schema versions above.
+# Desktop writes this into report.json's themeCollection.baseTheme.
+REPORT_VERSION_AT_IMPORT: dict[str, str] = {
+    "visual": "2.8.0",
+    "report": "3.2.0",
+    "page": "2.3.1",
+}
+
+
+def definition_schema(name: str) -> str:
+    """Return the full ``$schema`` URL for a report/definition/ file type.
+
+    >>> definition_schema("visualContainer")
+    'https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.9.0/schema.json'
+    """
+    try:
+        version = DEFINITION_SCHEMA_VERSIONS[name]
+    except KeyError as exc:  # pragma: no cover - guards typos at call sites
+        raise KeyError(
+            f"Unknown PBIR definition schema '{name}'. "
+            f"Known: {sorted(DEFINITION_SCHEMA_VERSIONS)}"
+        ) from exc
+    return f"{_BASE}/definition/{name}/{version}/schema.json"
+
+
+def item_schema(name: str) -> str:
+    """Return the full ``$schema`` URL for a report/ item file type (e.g. the
+    definition.pbir ``definitionProperties`` file)."""
+    try:
+        version = _ITEM_SCHEMA_VERSIONS[name]
+    except KeyError as exc:  # pragma: no cover
+        raise KeyError(
+            f"Unknown PBIR item schema '{name}'. Known: {sorted(_ITEM_SCHEMA_VERSIONS)}"
+        ) from exc
+    return f"{_BASE}/{name}/{version}/schema.json"

--- a/src/pbi_cli/commands/filter_cmd.py
+++ b/src/pbi_cli/commands/filter_cmd.py
@@ -1,4 +1,10 @@
-"""pbi filter — add relative-date, TopN, and basic filters to report pages."""
+"""pbi filter — add relative-date, value, and advanced filters to report pages.
+
+Filters are written to the page's ``filterConfig`` object using the official PBIR
+filterConfiguration schema (see :mod:`pbi_cli.intelligence.filter_builder`). The
+previous flat ``{operator, timeUnitsCount}`` shape did not match any published
+PBIR schema and is no longer produced.
+"""
 
 from __future__ import annotations
 
@@ -9,13 +15,14 @@ import click
 from rich.console import Console
 
 from pbi_cli.commands._shared import dry_run_echo, output_json_or_table
+from pbi_cli.intelligence import filter_builder as fb
 
 console = Console(legacy_windows=False)
 
 
 @click.group("filter")
 def filter_cmd() -> None:
-    """Add and manage filters on report pages (relative-date, TopN, basic value)."""
+    """Add and manage page filters (relative-date, value, advanced)."""
 
 
 def _page_json_path(pbip: str, page: str) -> Path:
@@ -38,11 +45,16 @@ def _page_json_path(pbip: str, page: str) -> Path:
     raise click.ClickException(f"page.json not found for page '{page}'.")
 
 
-def _append_filter(page_json: Path, filter_obj: dict) -> None:
+def _append_filter(page_json: Path, filter_container: dict) -> None:
+    """Append a FilterContainer into the page's ``filterConfig.filters``."""
     data = json.loads(page_json.read_text(encoding="utf-8"))
-    filters = data.setdefault("filters", [])
-    filters.append(filter_obj)
+    data["filterConfig"] = fb.add_filter(data.get("filterConfig"), filter_container)
     page_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def _read_filters(page_json: Path) -> list[dict]:
+    data = json.loads(page_json.read_text(encoding="utf-8"))
+    return data.get("filterConfig", {}).get("filters", [])
 
 
 @filter_cmd.command("list")
@@ -52,12 +64,31 @@ def _append_filter(page_json: Path, filter_obj: dict) -> None:
 def filter_list(ctx: click.Context, pbip: str, page: str) -> None:
     """List all filters applied to a report page."""
     pj = _page_json_path(pbip, page)
-    data = json.loads(pj.read_text(encoding="utf-8"))
-    filters = data.get("filters", [])
+    filters = _read_filters(pj)
     if not filters:
         console.print(f"[yellow]No filters on page '{page}'.[/yellow]")
         return
-    output_json_or_table(filters, ctx, title=f"Filters on '{page}'")
+    # Project to a friendly summary rather than dumping raw FilterDefinition JSON.
+    rows = [
+        {
+            "name": f.get("name", ""),
+            "type": f.get("type", ""),
+            "field": _describe_field(f.get("field", {})),
+            "locked": f.get("isLockedInViewMode", False),
+            "hidden": f.get("isHiddenInViewMode", False),
+        }
+        for f in filters
+    ]
+    output_json_or_table(rows, ctx, title=f"Filters on '{page}'")
+
+
+def _describe_field(field: dict) -> str:
+    for kind in ("Column", "Measure"):
+        node = field.get(kind)
+        if node:
+            entity = node.get("Expression", {}).get("SourceRef", {}).get("Source", "")
+            return f"{entity}.{node.get('Property', '')}" if entity else node.get("Property", "")
+    return ""
 
 
 @filter_cmd.command("add-relative-date")
@@ -68,10 +99,18 @@ def filter_list(ctx: click.Context, pbip: str, page: str) -> None:
 @click.option("--last", type=int, required=True, help="Number of time units (e.g. 30).")
 @click.option(
     "--unit",
-    type=click.Choice(["Days", "Weeks", "Months", "Quarters", "Years"]),
+    type=click.Choice(["Days", "Weeks", "Months", "Years"]),
     default="Days",
     show_default=True,
 )
+@click.option(
+    "--exclude-today/--include-today",
+    default=False,
+    show_default=True,
+    help="Exclude the current period from the range.",
+)
+@click.option("--locked", is_flag=True, help="Lock the filter in view mode.")
+@click.option("--hidden", is_flag=True, help="Hide the filter in view mode.")
 @click.pass_context
 def filter_add_relative_date(
     ctx: click.Context,
@@ -81,6 +120,9 @@ def filter_add_relative_date(
     column: str,
     last: int,
     unit: str,
+    exclude_today: bool,
+    locked: bool,
+    hidden: bool,
 ) -> None:
     """Add a relative-date filter to a page (e.g. 'last 30 days').
 
@@ -91,83 +133,15 @@ def filter_add_relative_date(
     """
     if dry_run_echo(ctx, f"add relative-date filter: last {last} {unit} on {table}[{column}]"):
         return
-
-    filter_obj = {
-        "type": "RelativeDate",
-        "field": {
-            "Column": {
-                "Expression": {"SourceRef": {"Entity": table}},
-                "Property": column,
-            }
-        },
-        "operator": "InTheLast",
-        "timeUnitsCount": last,
-        "timeUnitType": unit,
-    }
-
+    fc = fb.build_relative_date_filter(
+        table, column, last, unit, include_today=not exclude_today, locked=locked, hidden=hidden
+    )
     pj = _page_json_path(pbip, page)
-    _append_filter(pj, filter_obj)
+    _append_filter(pj, fc)
     console.print(
         f"[green]Filter added:[/green] last {last} {unit} on {table}[{column}] -> page '{page}'"
     )
-
-
-@filter_cmd.command("add-topn")
-@click.option("--pbip", required=True)
-@click.option("--page", required=True, help="Page to apply filter to.")
-@click.option("--table", required=True, help="Table containing the category field.")
-@click.option("--column", required=True, help="Column to filter (e.g. Product).")
-@click.option("--n", type=int, required=True, help="Number of top items to keep.")
-@click.option("--by-table", required=True, help="Table containing the measure to order by.")
-@click.option("--by-measure", required=True, help="Measure name to order by (e.g. Total Sales).")
-@click.option("--direction", type=click.Choice(["Top", "Bottom"]), default="Top", show_default=True)
-@click.pass_context
-def filter_add_topn(
-    ctx: click.Context,
-    pbip: str,
-    page: str,
-    table: str,
-    column: str,
-    n: int,
-    by_table: str,
-    by_measure: str,
-    direction: str,
-) -> None:
-    """Add a TopN filter to keep only the top (or bottom) N items by a measure.
-
-    \b
-    Example:
-      pbi filter add-topn --pbip MyReport --page "Sales" \\
-        --table Products --column Product --n 10 \\
-        --by-table Sales --by-measure "Total Sales"
-    """
-    if dry_run_echo(ctx, f"add TopN filter: {direction} {n} {table}[{column}] by {by_measure}"):
-        return
-
-    operator = "TopCount" if direction == "Top" else "BottomCount"
-    filter_obj = {
-        "type": "TopN",
-        "field": {
-            "Column": {
-                "Expression": {"SourceRef": {"Entity": table}},
-                "Property": column,
-            }
-        },
-        "operator": operator,
-        "itemCount": {"Literal": {"Value": str(n)}},
-        "orderByField": {
-            "Measure": {
-                "Expression": {"SourceRef": {"Entity": by_table}},
-                "Property": by_measure,
-            }
-        },
-    }
-
-    pj = _page_json_path(pbip, page)
-    _append_filter(pj, filter_obj)
-    console.print(
-        f"[green]Filter added:[/green] {direction} {n} {table}[{column}] by '{by_measure}' -> page '{page}'"  # noqa: E501
-    )
+    console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
 
 
 @filter_cmd.command("add-value")
@@ -175,7 +149,10 @@ def filter_add_topn(
 @click.option("--page", required=True)
 @click.option("--table", required=True)
 @click.option("--column", required=True)
-@click.option("--values", required=True, help="Comma-separated list of values to include.")
+@click.option("--values", required=True, help="Comma-separated list of values.")
+@click.option("--exclude", is_flag=True, help="Exclude these values instead of including them.")
+@click.option("--locked", is_flag=True, help="Lock the filter in view mode.")
+@click.option("--hidden", is_flag=True, help="Hide the filter in view mode.")
 @click.pass_context
 def filter_add_value(
     ctx: click.Context,
@@ -184,39 +161,100 @@ def filter_add_value(
     table: str,
     column: str,
     values: str,
+    exclude: bool,
+    locked: bool,
+    hidden: bool,
 ) -> None:
-    """Add a basic value-in filter to a page.
+    """Add a categorical (value-in/-out) filter to a page.
 
     \b
     Example:
       pbi filter add-value --pbip MyReport --page "Sales" \\
         --table financials --column Segment --values "Enterprise,Government"
     """
-    if dry_run_echo(ctx, f"add value filter: {table}[{column}] in [{values}]"):
-        return
-
     value_list = [v.strip() for v in values.split(",") if v.strip()]
-    filter_conditions = [
-        {"operator": "Is", "value": {"Literal": {"Value": f"'{v}'"}}} for v in value_list
-    ]
-
-    filter_obj = {
-        "type": "BasicFilter",
-        "field": {
-            "Column": {
-                "Expression": {"SourceRef": {"Entity": table}},
-                "Property": column,
-            }
-        },
-        "operator": "In",
-        "values": filter_conditions,
-    }
-
-    pj = _page_json_path(pbip, page)
-    _append_filter(pj, filter_obj)
-    console.print(
-        f"[green]Filter added:[/green] {table}[{column}] in {value_list} -> page '{page}'"
+    if not value_list:
+        raise click.UsageError("--values must contain at least one value.")
+    verb = "exclude" if exclude else "include"
+    if dry_run_echo(ctx, f"add value filter: {verb} {table}[{column}] in {value_list}"):
+        return
+    fc = fb.build_value_filter(
+        table, column, value_list, exclude=exclude, locked=locked, hidden=hidden
     )
+    pj = _page_json_path(pbip, page)
+    _append_filter(pj, fc)
+    console.print(
+        f"[green]Filter added:[/green] {verb} {table}[{column}] in {value_list} -> page '{page}'"
+    )
+    console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
+
+
+@filter_cmd.command("add-advanced")
+@click.option("--pbip", required=True)
+@click.option("--page", required=True)
+@click.option("--table", required=True)
+@click.option("--column", required=True, help="Column or measure to filter.")
+@click.option("--measure", "is_measure", is_flag=True, help="Treat --column as a DAX measure.")
+@click.option(
+    "--condition",
+    "conditions",
+    multiple=True,
+    required=True,
+    help="Condition as 'OP:VALUE' (e.g. '>=:1000'). Repeatable, max two.",
+)
+@click.option(
+    "--logic",
+    type=click.Choice(["And", "Or"]),
+    default="And",
+    show_default=True,
+    help="How to join two conditions.",
+)
+@click.option("--locked", is_flag=True, help="Lock the filter in view mode.")
+@click.option("--hidden", is_flag=True, help="Hide the filter in view mode.")
+@click.pass_context
+def filter_add_advanced(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    table: str,
+    column: str,
+    is_measure: bool,
+    conditions: tuple[str, ...],
+    logic: str,
+    locked: bool,
+    hidden: bool,
+) -> None:
+    """Add an advanced numeric filter (one or two comparisons) to a page.
+
+    \b
+    Example — keep rows where Profit is between 0 and 1,000,000:
+      pbi filter add-advanced --pbip MyReport --page "Sales" \\
+        --table financials --column Profit \\
+        --condition ">=:0" --condition "<=:1000000" --logic And
+    """
+    parsed: list[tuple[str, float]] = []
+    for c in conditions:
+        if ":" not in c:
+            raise click.UsageError(f"--condition '{c}' must be 'OP:VALUE' (e.g. '>=:1000').")
+        op, _, raw = c.partition(":")
+        try:
+            parsed.append((op.strip(), float(raw)))
+        except ValueError as exc:
+            raise click.UsageError(f"--condition '{c}' has a non-numeric threshold.") from exc
+    if dry_run_echo(ctx, f"add advanced filter on {table}[{column}]: {parsed} ({logic})"):
+        return
+    try:
+        fc = fb.build_advanced_filter(
+            table, column, parsed, logic=logic, is_measure=is_measure, locked=locked, hidden=hidden
+        )
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+    pj = _page_json_path(pbip, page)
+    _append_filter(pj, fc)
+    console.print(
+        f"[green]Filter added:[/green] advanced {table}[{column}] {parsed} -> page '{page}'"
+    )
+    console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
 
 
 @filter_cmd.command("clear")
@@ -229,7 +267,8 @@ def filter_clear(ctx: click.Context, pbip: str, page: str) -> None:
         return
     pj = _page_json_path(pbip, page)
     data = json.loads(pj.read_text(encoding="utf-8"))
-    count = len(data.get("filters", []))
-    data["filters"] = []
+    count = len(data.get("filterConfig", {}).get("filters", []))
+    if "filterConfig" in data:
+        data["filterConfig"]["filters"] = []
     pj.write_text(json.dumps(data, indent=2), encoding="utf-8")
     console.print(f"[green]Cleared[/green] {count} filter(s) from page '{page}'.")

--- a/src/pbi_cli/commands/visual.py
+++ b/src/pbi_cli/commands/visual.py
@@ -983,3 +983,193 @@ def visual_mobile(
     else:
         console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
         raise SystemExit(1)
+
+
+# ── Multi-role rebind & generic formatting ──────────────────────────────────────
+
+
+def _parse_bind(spec: str):
+    """Parse a 'ROLE/TABLE/FIELD[/KIND]' bind spec into (role, FieldDef).
+
+    KIND is one of: col, sum, avg, min, max, count, measure (default: sum).
+    """
+    from pbi_cli.intelligence.visual_builder import FieldDef
+
+    parts = spec.split("/")
+    if len(parts) < 3:
+        raise click.UsageError(
+            f"--bind '{spec}' must be ROLE/TABLE/FIELD[/KIND] (e.g. 'Y/financials/Sales/sum')."
+        )
+    role, table, fieldname = parts[0], parts[1], parts[2]
+    kind = parts[3].lower() if len(parts) > 3 else "sum"
+    if not (role and table and fieldname):
+        raise click.UsageError(f"--bind '{spec}' has an empty ROLE, TABLE or FIELD.")
+    if kind == "measure":
+        fd = FieldDef(entity=table, property=fieldname, is_measure=True)
+    elif kind == "col":
+        fd = FieldDef(entity=table, property=fieldname, agg=None)
+    elif kind in AGG_MAP and AGG_MAP[kind] >= 0:
+        fd = FieldDef(entity=table, property=fieldname, agg=AGG_MAP[kind])
+    else:
+        raise click.UsageError(
+            f"--bind '{spec}' has unknown KIND '{kind}'; use col/sum/avg/min/max/count/measure."
+        )
+    return role, fd
+
+
+@visual.command("rebind")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Page display name.")
+@click.option("--name", "visual_name", required=True, help="Visual name (from pbi visual list).")
+@click.option(
+    "--bind",
+    "binds",
+    multiple=True,
+    required=True,
+    help="Role binding 'ROLE/TABLE/FIELD[/KIND]' (repeatable). "
+    "KIND: col, sum, avg, min, max, count, measure (default sum). "
+    "Repeat the same ROLE to put multiple fields in one slot.",
+)
+@click.option(
+    "--clear-unlisted",
+    is_flag=True,
+    help="Remove every role not given here (full atomic rebind).",
+)
+@click.pass_context
+def visual_rebind(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    visual_name: str,
+    binds: tuple[str, ...],
+    clear_unlisted: bool,
+) -> None:
+    """Rebind several role slots of a visual at once, in a single atomic write.
+
+    Unlike ``set-field`` (one role), this rewrites multiple roles together and
+    preserves the visual's position, title and formatting. With --clear-unlisted
+    the visual ends up bound to exactly what you pass — the safe in-place
+    equivalent of delete + re-add.
+
+    \b
+    Example — turn a chart into Country/Sales+Profit:
+      pbi visual rebind --pbip R --page "Sales" --name abc123 \\
+        --bind "Category/financials/Country/col" \\
+        --bind "Y/financials/Sales/sum" --bind "Y/financials/Profit/sum" \\
+        --clear-unlisted
+    """
+    if dry_run_echo(ctx, f"rebind {len(binds)} role binding(s) on visual '{visual_name}'"):
+        return
+
+    bindings: dict[str, list] = {}
+    for spec in binds:
+        role, fd = _parse_bind(spec)
+        bindings.setdefault(role, []).append(fd)
+
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        ok = b.visual_rebind(page, visual_name, bindings, clear_unlisted=clear_unlisted)
+    except (ValueError, RuntimeError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    if ok:
+        roles = ", ".join(bindings)
+        console.print(f"[green]Rebound[/green] roles [{roles}] on visual '{visual_name}'.")
+        console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
+    else:
+        console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
+        raise SystemExit(1)
+
+
+@visual.command("set-format")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Page display name.")
+@click.option("--name", "visual_name", required=True, help="Visual name (from pbi visual list).")
+@click.option(
+    "--object",
+    "object_name",
+    required=True,
+    help="Formatting object, e.g. title, background, legend, dataLabels, categoryAxis.",
+)
+@click.option("--property", "property_name", required=True, help="Property on the object.")
+@click.option("--value", required=True, help="Value to set.")
+@click.option(
+    "--type",
+    "value_type",
+    type=click.Choice(["auto", "text", "number", "bool", "color"]),
+    default="auto",
+    show_default=True,
+    help="How to interpret --value.",
+)
+@click.option(
+    "--container",
+    "container_level",
+    is_flag=True,
+    help="Target visualContainerObjects (title/background/border/header) instead "
+    "of the type-specific objects.",
+)
+@click.pass_context
+def visual_set_format(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    visual_name: str,
+    object_name: str,
+    property_name: str,
+    value: str,
+    value_type: str,
+    container_level: bool,
+) -> None:
+    """Set any formatting-object property on a visual (general formatting writer).
+
+    Goes beyond conditional formatting: turn data labels on, set a legend
+    position, recolour the background, change an axis title, and so on.
+
+    \b
+    Examples:
+      pbi visual set-format --pbip R --page "Sales" --name abc --container \\
+        --object title --property show --value true --type bool
+      pbi visual set-format --pbip R --page "Sales" --name abc \\
+        --object legend --property position --value Top
+      pbi visual set-format --pbip R --page "Sales" --name abc --container \\
+        --object background --property color --value "#F5F5F5" --type color
+    """
+    if dry_run_echo(
+        ctx, f"set {object_name}.{property_name}={value} on visual '{visual_name}'"
+    ):
+        return
+
+    # Coerce the string --value to the right Python type for 'auto'/typed writes.
+    coerced: object = value
+    if value_type == "number":
+        coerced = float(value)
+    elif value_type == "bool":
+        coerced = value.strip().lower() in ("true", "1", "yes", "on")
+
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        ok = b.visual_set_format(
+            page,
+            visual_name,
+            object_name,
+            property_name,
+            coerced,
+            value_type=value_type,
+            container_level=container_level,
+        )
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    if ok:
+        console.print(
+            f"[green]Format set:[/green] {object_name}.{property_name} = {value} "
+            f"on visual '{visual_name}'."
+        )
+        console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
+    else:
+        console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
+        raise SystemExit(1)

--- a/src/pbi_cli/intelligence/filter_builder.py
+++ b/src/pbi_cli/intelligence/filter_builder.py
@@ -1,0 +1,304 @@
+"""Build schema-valid PBIR filter definitions (``filterConfig`` entries).
+
+Grounded in the official Microsoft schemas:
+
+  filterConfiguration : .../report/definition/filterConfiguration/1.3.0/schema.json
+  semanticQuery       : .../report/definition/semanticQuery/1.4.0/schema.json
+
+A page/report/visual stores its filters in a ``filterConfig`` object::
+
+    "filterConfig": {
+        "$schema": ".../filterConfiguration/1.3.0/schema.json",
+        "filters": [ FilterContainer, ... ]
+    }
+
+Each FilterContainer carries metadata (``name`` is the only required field) plus a
+``filter`` whose value is a *FilterDefinition* — a partial semantic query of the
+shape ``{ "Version": 2, "From": [...], "Where": [...] }``. The ``Where`` holds the
+actual boolean condition as a QueryExpressionContainer (``In``, ``Comparison``,
+``And``, ``Not`` ...).
+
+This module deliberately replaces the previous flat ``{operator, timeUnitsCount}``
+shape, which did not match any published PBIR schema and would be rejected by
+Power BI Desktop as a blocking error.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+
+# QueryComparisonKind (semanticQuery schema)
+COMPARISON_KIND = {"=": 0, "==": 0, ">": 1, ">=": 2, "<": 3, "<=": 4}
+
+# TimeUnit (semanticQuery schema)
+TIME_UNIT = {"Days": 0, "Weeks": 1, "Months": 2, "Years": 3, "Decades": 4,
+             "Seconds": 5, "Minutes": 6, "Hours": 7}
+
+
+def _alias(table: str) -> str:
+    """Short query alias for a table, matching Desktop's style (e.g. 'f')."""
+    first = next((c for c in table if c.isalpha()), "t")
+    return first.lower()
+
+
+def _filter_name() -> str:
+    """A unique 20-char filter name, matching Desktop's id convention."""
+    return uuid.uuid4().hex[:20]
+
+
+def _source_ref(alias: str) -> dict[str, Any]:
+    return {"SourceRef": {"Source": alias}}
+
+
+def _column(alias: str, column: str) -> dict[str, Any]:
+    return {"Column": {"Expression": _source_ref(alias), "Property": column}}
+
+
+def _measure(alias: str, measure: str) -> dict[str, Any]:
+    return {"Measure": {"Expression": _source_ref(alias), "Property": measure}}
+
+
+def _string_literal(value: str) -> dict[str, Any]:
+    # String literals are single-quoted inside the Value per the literal grammar.
+    return {"Literal": {"Value": f"'{value}'"}}
+
+
+def _num_literal(value: float | int) -> dict[str, Any]:
+    if isinstance(value, float) and value.is_integer():
+        value = int(value)
+    # Numbers use the 'D' (double) suffix in the literal grammar.
+    return {"Literal": {"Value": f"{value}D"}}
+
+
+def _container(
+    *,
+    name: str,
+    field: dict[str, Any],
+    filter_type: str,
+    definition: dict[str, Any],
+    locked: bool = False,
+    hidden: bool = False,
+    display_name: str | None = None,
+) -> dict[str, Any]:
+    """Assemble a FilterContainer. ``howCreated='User'`` marks it as added by a
+    user/tool against a field not necessarily on a visual (vs. 'Auto')."""
+    container: dict[str, Any] = {
+        "name": name,
+        "field": field,
+        "type": filter_type,
+        "filter": definition,
+        "howCreated": "User",
+    }
+    if display_name:
+        container["displayName"] = display_name
+    if locked:
+        container["isLockedInViewMode"] = True
+    if hidden:
+        container["isHiddenInViewMode"] = True
+    return container
+
+
+# ── Public builders ─────────────────────────────────────────────────────────────
+
+
+def build_value_filter(
+    table: str,
+    column: str,
+    values: list[str],
+    *,
+    exclude: bool = False,
+    locked: bool = False,
+    hidden: bool = False,
+) -> dict[str, Any]:
+    """A categorical (value-in) filter: keep rows where ``column`` is in ``values``.
+
+    With ``exclude=True`` the condition is negated (``Not In``) and the filter type
+    becomes ``Exclude`` — the standard way Desktop records an exclusion filter.
+    """
+    if not values:
+        raise ValueError("at least one value is required")
+    alias = _alias(table)
+    col = _column(alias, column)
+    in_expr = {
+        "In": {
+            "Expressions": [col],
+            "Values": [[_string_literal(v)] for v in values],
+        }
+    }
+    condition = {"Not": {"Expression": in_expr}} if exclude else in_expr
+    definition = {
+        "Version": 2,
+        "From": [{"Name": alias, "Entity": table, "Type": 0}],
+        "Where": [{"Condition": condition}],
+    }
+    return _container(
+        name=_filter_name(),
+        field=col,
+        filter_type="Exclude" if exclude else "Categorical",
+        definition=definition,
+        locked=locked,
+        hidden=hidden,
+    )
+
+
+def build_advanced_filter(
+    table: str,
+    column: str,
+    conditions: list[tuple[str, float]],
+    *,
+    logic: str = "And",
+    is_measure: bool = False,
+    locked: bool = False,
+    hidden: bool = False,
+) -> dict[str, Any]:
+    """An advanced numeric filter: one or two comparisons joined by And/Or.
+
+    ``conditions`` is a list of ``(operator, threshold)`` where operator is one of
+    ``= > >= < <=``. Power BI advanced filters allow up to two conditions; more
+    than two raises ``ValueError``.
+    """
+    if not conditions:
+        raise ValueError("at least one condition is required")
+    if len(conditions) > 2:
+        raise ValueError("advanced filters allow at most two conditions")
+    if logic not in ("And", "Or"):
+        raise ValueError("logic must be 'And' or 'Or'")
+
+    alias = _alias(table)
+    left = _measure(alias, column) if is_measure else _column(alias, column)
+
+    def _cmp(op: str, threshold: float) -> dict[str, Any]:
+        if op not in COMPARISON_KIND:
+            raise ValueError(f"unknown operator '{op}'; use one of {sorted(COMPARISON_KIND)}")
+        return {
+            "Comparison": {
+                "ComparisonKind": COMPARISON_KIND[op],
+                "Left": left,
+                "Right": _num_literal(threshold),
+            }
+        }
+
+    comparisons = [_cmp(op, thr) for op, thr in conditions]
+    condition = (
+        comparisons[0]
+        if len(comparisons) == 1
+        else {logic: {"Left": comparisons[0], "Right": comparisons[1]}}
+    )
+    definition = {
+        "Version": 2,
+        "From": [{"Name": alias, "Entity": table, "Type": 0}],
+        "Where": [{"Condition": condition}],
+    }
+    return _container(
+        name=_filter_name(),
+        field=left,
+        filter_type="Advanced",
+        definition=definition,
+        locked=locked,
+        hidden=hidden,
+    )
+
+
+def build_relative_date_filter(
+    table: str,
+    column: str,
+    last: int,
+    unit: str = "Days",
+    *,
+    include_today: bool = True,
+    locked: bool = False,
+    hidden: bool = False,
+) -> dict[str, Any]:
+    """A relative-date filter keeping the last ``last`` ``unit`` up to now.
+
+    PBIR expresses this as an advanced date range on the column::
+
+        column >= DateAdd(Now(), -last, unit)   [ AND column <= Now() ]
+
+    ``DateAdd``/``Now`` are first-class semantic-query expressions, so the result
+    is a valid date-range condition. ``include_today=False`` adds the upper bound
+    ``column < DateSpan(Now(), unit)`` to exclude the current period.
+    """
+    if last <= 0:
+        raise ValueError("last must be a positive integer")
+    if unit not in TIME_UNIT:
+        raise ValueError(f"unit must be one of {sorted(TIME_UNIT)}")
+    alias = _alias(table)
+    col = _column(alias, column)
+    unit_num = TIME_UNIT[unit]
+
+    lower_bound = {
+        "DateAdd": {
+            "Amount": -last,
+            "TimeUnit": unit_num,
+            "Expression": {"Now": {}},
+        }
+    }
+    ge = {
+        "Comparison": {
+            "ComparisonKind": COMPARISON_KIND[">="],
+            "Left": col,
+            "Right": lower_bound,
+        }
+    }
+    if include_today:
+        condition: dict[str, Any] = ge
+    else:
+        # Exclude the current period: column < start of this period.
+        upper_bound = {"DateSpan": {"TimeUnit": unit_num, "Expression": {"Now": {}}}}
+        lt = {
+            "Comparison": {
+                "ComparisonKind": COMPARISON_KIND["<"],
+                "Left": col,
+                "Right": upper_bound,
+            }
+        }
+        condition = {"And": {"Left": ge, "Right": lt}}
+
+    definition = {
+        "Version": 2,
+        "From": [{"Name": alias, "Entity": table, "Type": 0}],
+        "Where": [{"Condition": condition}],
+    }
+    return _container(
+        name=_filter_name(),
+        field=col,
+        filter_type="RelativeDate",
+        definition=definition,
+        locked=locked,
+        hidden=hidden,
+    )
+
+
+# ── filterConfig envelope helpers ───────────────────────────────────────────────
+# NOTE: a `filterConfig` embedded in page.json / report.json / visual.json is the
+# filterConfiguration schema *inlined by $ref*. Power BI Desktop's runtime
+# validator rejects a `$schema` key inside this embedded object ("An additional
+# property '$schema' was included in the /filterConfig property") — verified live
+# 2026-06-22. Only standalone filter files would carry `$schema`. So the embedded
+# object holds just `filters` (and optionally `filterSortOrder`).
+
+
+def empty_filter_config() -> dict[str, Any]:
+    """A fresh, empty embedded filterConfig object (no ``$schema`` — see note)."""
+    return {"filters": []}
+
+
+def add_filter(config: dict[str, Any] | None, filter_container: dict[str, Any]) -> dict[str, Any]:
+    """Append ``filter_container`` to an embedded filterConfig, creating one if
+    needed. Strips any stray ``$schema`` (Desktop rejects it here). Returns the
+    (possibly new) config object."""
+    cfg = config or empty_filter_config()
+    cfg.pop("$schema", None)
+    cfg.setdefault("filters", []).append(filter_container)
+    return cfg
+
+
+_NAME_RE = re.compile(r"^[\w-]+$")
+
+
+def is_valid_name(name: str) -> bool:
+    """PBIR object names must be word chars or hyphens (per the naming convention)."""
+    return bool(name) and bool(_NAME_RE.match(name))

--- a/src/pbi_cli/intelligence/visual_builder.py
+++ b/src/pbi_cli/intelligence/visual_builder.py
@@ -1,8 +1,8 @@
 """Build Power BI PBIR GA visual JSON blobs.
 
-Schema reference:
+Schema reference (versions are centralised in ``pbi_cli.backends.pbir_schemas``):
   visualContainer: https://developer.microsoft.com/json-schemas/fabric/item/
-                   report/definition/visualContainer/2.7.0/schema.json
+                   report/definition/visualContainer/<version>/schema.json
   visualConfiguration (embedded inside "visual" key):
     - visualType, query, objects, visualContainerObjects
   query.queryState:
@@ -21,6 +21,8 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
+from pbi_cli.backends import pbir_schemas as _schemas
+
 AGG_SUM = 0
 AGG_AVG = 1
 AGG_MIN = 2
@@ -28,10 +30,7 @@ AGG_MAX = 3
 AGG_COUNT = 4
 AGG_NAMES = {AGG_SUM: "Sum", AGG_AVG: "Avg", AGG_MIN: "Min", AGG_MAX: "Max", AGG_COUNT: "Count"}
 
-VISUAL_CONTAINER_SCHEMA = (
-    "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/"
-    "visualContainer/2.7.0/schema.json"
-)
+VISUAL_CONTAINER_SCHEMA = _schemas.definition_schema("visualContainer")
 
 
 @dataclass

--- a/src/pbi_cli/project_scaffold.py
+++ b/src/pbi_cli/project_scaffold.py
@@ -13,6 +13,7 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from pbi_cli.backends import pbir_schemas as _schemas
 from pbi_cli.backends.pbir_backend import PbirBackend
 from pbi_cli.intelligence.visual_builder import (
     AGG_SUM,
@@ -158,8 +159,7 @@ def _write_report(root: Path, name: str, table: str) -> PbirBackend:
     (rep / "definition.pbir").write_text(
         json.dumps(
             {
-                "$schema": "https://developer.microsoft.com/json-schemas/fabric/"
-                "item/report/definitionProperties/2.0.0/schema.json",
+                "$schema": _schemas.item_schema("definitionProperties"),
                 "version": "4.0",
                 "datasetReference": {"byPath": {"path": f"../{name}.SemanticModel"}},
             },
@@ -171,8 +171,7 @@ def _write_report(root: Path, name: str, table: str) -> PbirBackend:
     (rep / "definition" / "version.json").write_text(
         json.dumps(
             {
-                "$schema": "https://developer.microsoft.com/json-schemas/fabric/"
-                "item/report/definition/versionMetadata/1.0.0/schema.json",
+                "$schema": _schemas.definition_schema("versionMetadata"),
                 "version": "2.0.0",
             },
             indent=2,

--- a/src/pbi_cli/skills/power-bi-custom-visuals/SKILL.md
+++ b/src/pbi_cli/skills/power-bi-custom-visuals/SKILL.md
@@ -60,7 +60,7 @@ The `visual.json` for a custom visual uses `visualType` set to the visual's GUID
 
 ```json
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.7.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.9.0/schema.json",
   "name": "a1b2c3d4e5f6",
   "position": { "x": 16, "y": 16, "z": 0, "width": 600, "height": 400, "tabOrder": 0 },
   "visual": {

--- a/src/pbi_cli/skills/power-bi-report/SKILL.md
+++ b/src/pbi_cli/skills/power-bi-report/SKILL.md
@@ -160,4 +160,4 @@ Minimum valid `page.json`:
 | `No *.Report folder found` | Save as .pbip first (File → Save as → Power BI project) |
 | Page not appearing after scaffold | Click Reload in Desktop; or close/reopen .pbip |
 | Visuals appear but show errors | Check field names match your model — use `pbi model columns` |
-| Schema validation error on reload | Check visual.json `$schema` matches `visualContainer/2.7.0/schema.json` |
+| Schema validation error on reload | Check visual.json `$schema` matches `visualContainer/2.9.0/schema.json` |

--- a/src/pbi_cli/skills/power-bi-troubleshooter/SKILL.md
+++ b/src/pbi_cli/skills/power-bi-troubleshooter/SKILL.md
@@ -98,7 +98,7 @@ pbi govern check
 | `No running Power BI Desktop found` | Desktop not open | Open your .pbip file in Desktop |
 | `Port 0 in netstat` | Model still loading | Wait 10s, run `pbi connect` again |
 | `Access denied to MSMDSRV` | User mismatch | Run terminal as same user as Desktop |
-| `$schema property did not match` | Wrong schema URL | Use `visualContainer/2.7.0/schema.json` |
+| `$schema property did not match` | Wrong schema URL | Use `visualContainer/2.9.0/schema.json` |
 | `Additional property ... not allowed` | Old visual format | Use `query.queryState` structure |
 | `Column not found` | Field name typo | Run `pbi model columns` to check exact name |
 | `XMLA endpoint not enabled` | Free/Pro workspace | Upgrade to Premium or Fabric |
@@ -136,7 +136,7 @@ cat "financials.Report/definition/pages/{pageGUID}/visuals/{visualGUID}/visual.j
 ```
 
 Check against the PBIR GA spec:
-- `$schema`: must be `visualContainer/2.7.0/schema.json`
+- `$schema`: must be `visualContainer/2.9.0/schema.json`
 - `visual.visualType`: must be a valid type string
 - `visual.query.queryState`: must use role keys (Values, Category, Y, etc.)
 - No direct `projections` or `prototypeQuery` at `visual` level

--- a/src/pbi_cli/skills/power-bi-visuals/SKILL.md
+++ b/src/pbi_cli/skills/power-bi-visuals/SKILL.md
@@ -109,7 +109,7 @@ Each visual is stored in `definition/pages/{pageId}/visuals/{visualId}/visual.js
 
 ```json
 {
-  "$schema": "https://developer.microsoft.com/.../visualContainer/2.7.0/schema.json",
+  "$schema": "https://developer.microsoft.com/.../visualContainer/2.9.0/schema.json",
   "name": "abc123def456",
   "position": { "x": 16, "y": 16, "z": 0, "width": 200, "height": 120, "tabOrder": 0 },
   "visual": {
@@ -158,7 +158,7 @@ Run `pbi visual recommend --measures "Total Sales,Profit,Units"` for AI-powered 
 | Issue | Cause | Fix |
 |-------|-------|-----|
 | Visual appears empty after reload | Field name typo | Run `pbi model columns` to verify exact column name |
-| Schema validation errors | Wrong `$schema` URL | Ensure `visualContainer/2.7.0/schema.json` |
+| Schema validation errors | Wrong `$schema` URL | Ensure `visualContainer/2.9.0/schema.json` |
 | "Additional property" error | Old `projections` format | Use new `query.queryState` format (current pbi-cli version) |
 | Title not showing | `visualContainerObjects` missing | Pass `--title` flag to `pbi visual add` |
 | All visuals stack at same position | Auto-position bug | Use explicit `--x` and `--y` flags |

--- a/tests/fixtures/pbir_schemas/filterConfiguration-1.3.0.schema.json
+++ b/tests/fixtures/pbir_schemas/filterConfiguration-1.3.0.schema.json
@@ -1,0 +1,193 @@
+{
+    "$id": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/filterConfiguration/1.3.0/schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Filter configuration",
+    "description": "Defines the configuration of filters.",
+    "type": "object",
+    "properties": {
+        "$schema": {
+            "description": "Defines the schema to use for an item.",
+            "type": "string",
+            "const": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/filterConfiguration/1.3.0/schema.json"
+        },
+        "filters": {
+            "description": "Defines the definitions and metadata for the filters.",
+            "type": "array",
+            "items": {
+                "$ref": "#/definitions/FilterContainer"
+            }
+        },
+        "filterSortOrder": {
+            "description": "Defines how the filters sorted - by name or custom sorting\nIf custom sorting, then ordinal property of every filter is used as the sort order,\nfilters where ordinal is skipped will be shown at the end; ordering will fallback to display name of the field.",
+            "type": "string",
+            "anyOf": [
+                {
+                    "const": "Ascending",
+                    "description": "Sorted ascending by display name of the filter field."
+                },
+                {
+                    "const": "Descending",
+                    "description": "Sorted descending by display name of the filter field."
+                },
+                {
+                    "const": "Custom",
+                    "description": "Sorted ascending by ordinal property of filters."
+                }
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "$schema"
+    ],
+    "definitions": {
+        "FilterContainer": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "description": "A unique name (across the whole report definition) defined for this filter.",
+                    "type": "string"
+                },
+                "displayName": {
+                    "description": "An alternate name to use when displaying this filter - by default the display name of the field will be used, if there is no field or display name,\nthen restatement of the filter will be shown. Only applies to certain filter types.",
+                    "type": "string"
+                },
+                "ordinal": {
+                    "description": "Defines the ordering of this filter w.r.t. other filters - only applies when Custom sort order is set.",
+                    "type": "number"
+                },
+                "field": {
+                    "description": "Defines the field from your data that is filtered.",
+                    "$ref": "../../semanticQuery/1.4.0/schema.json#/definitions/QueryExpressionContainer"
+                },
+                "type": {
+                    "description": "The type of a filter.",
+                    "type": "string",
+                    "anyOf": [
+                        {
+                            "const": "Categorical"
+                        },
+                        {
+                            "const": "Range"
+                        },
+                        {
+                            "const": "Advanced"
+                        },
+                        {
+                            "const": "Passthrough"
+                        },
+                        {
+                            "const": "TopN"
+                        },
+                        {
+                            "const": "Include"
+                        },
+                        {
+                            "const": "Exclude"
+                        },
+                        {
+                            "const": "RelativeDate"
+                        },
+                        {
+                            "const": "Tuple"
+                        },
+                        {
+                            "const": "RelativeTime"
+                        },
+                        {
+                            "const": "VisualTopN"
+                        }
+                    ]
+                },
+                "filter": {
+                    "description": "Defines the actual filter definition - it is dependent on the type of filter.",
+                    "$ref": "../../semanticQuery/1.4.0/schema.json#/definitions/FilterDefinition"
+                },
+                "restatement": {
+                    "description": "A custom restatement to show for the filter - only applies to Passthrough filter type. For all other filters, a restatement is generated based on the filter definition.",
+                    "type": "string"
+                },
+                "howCreated": {
+                    "description": "Specifies how this filter was first created.",
+                    "type": "string",
+                    "anyOf": [
+                        {
+                            "const": "Auto",
+                            "description": "Created automatically when a field is used in the visual."
+                        },
+                        {
+                            "const": "User",
+                            "description": "Filters created from fields not used in a visual by the user."
+                        },
+                        {
+                            "const": "Drill",
+                            "description": "Created when drilling down on a data point in a visual."
+                        },
+                        {
+                            "const": "Include",
+                            "description": "Created by including a data point in a visual."
+                        },
+                        {
+                            "const": "Exclude",
+                            "description": "Created by excluding a data point from a visual."
+                        },
+                        {
+                            "const": "Drillthrough",
+                            "description": "Created by drill context that is applied to the page when using drill-through\naction from another page."
+                        }
+                    ]
+                },
+                "isHiddenInViewMode": {
+                    "description": "Defines whether to hide this filter when viewing the report.",
+                    "type": "boolean"
+                },
+                "isLockedInViewMode": {
+                    "description": "Defines whether the filter value can be changed when viewing the report.",
+                    "type": "boolean"
+                },
+                "objects": {
+                    "description": "Formatting for different \"objects\" of a filter card",
+                    "$ref": "#/definitions/FilterContainerFormattingObjects"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "name"
+            ]
+        },
+        "FilterContainerFormattingObjects": {
+            "type": "object",
+            "properties": {
+                "general": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "selector": {
+                                "description": "Defines the scope at which to apply the formatting for this object.\nCan also define rules for matching highlighted values and how multiple definitions for the same property should be ordered.",
+                                "$ref": "../../formattingObjectDefinitions/1.5.0/schema.json#/definitions/Selector"
+                            },
+                            "properties": {
+                                "$ref": "#/definitions/FilterContainerFormattingObjectsProperties",
+                                "description": "Describes the properties of the object to apply formatting changes to."
+                            }
+                        },
+                        "additionalProperties": false,
+                        "required": [
+                            "properties"
+                        ]
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "FilterContainerFormattingObjectsProperties": {
+            "type": "object",
+            "properties": {
+                "requireSingleSelect": {},
+                "isInvertedSelectionMode": {}
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/tests/fixtures/pbir_schemas/formattingObjectDefinitions-1.5.0.schema.json
+++ b/tests/fixtures/pbir_schemas/formattingObjectDefinitions-1.5.0.schema.json
@@ -1,0 +1,160 @@
+{
+    "$id": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/formattingObjectDefinitions/1.5.0/schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Formatting Object Definitions",
+    "description": "Defines shared definitions for report object formatting.",
+    "definitions": {
+        "DataViewObjectDefinitions": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/DataViewObjectDefinition"
+                }
+            }
+        },
+        "DataViewObjectDefinition": {
+            "type": "object",
+            "properties": {
+                "selector": {
+                    "$ref": "#/definitions/Selector"
+                },
+                "properties": {
+                    "$ref": "#/definitions/DataViewObjectPropertyDefinitions"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "properties"
+            ]
+        },
+        "DataViewObjectPropertyDefinitions": {
+            "type": "object",
+            "additionalProperties": {}
+        },
+        "Selector": {
+            "type": "object",
+            "properties": {
+                "data": {
+                    "description": "Scope is defined by data bound to the visual.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/DataRepetitionSelector"
+                    }
+                },
+                "metadata": {
+                    "description": "Defines the scope to a specific field.",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "User defined scope.",
+                    "type": "string"
+                },
+                "highlightMatching": {
+                    "description": "Describes how the Selector should behave towards Highlighted Values within the Scope matched by that Selector.",
+                    "default": 0,
+                    "type": "number",
+                    "anyOf": [
+                        {
+                            "const": 0,
+                            "description": "Only non-highlighted value will be selected, even if a highlighted value exists."
+                        },
+                        {
+                            "const": 1,
+                            "description": "Non-highlighted values are selected. If highlighted values exist, they are selected as well."
+                        },
+                        {
+                            "const": 2,
+                            "description": "If a highlighted value exists, it's selected. Otherwise, the non-highlighted value is selected."
+                        }
+                    ]
+                },
+                "hierarchyMatching": {
+                    "description": "Describes how the selector matches hierarchy values.\nThis also changes how the query is generated for {@link DataViewScopeWildcard} selectors.\nNow those selectors can produce scopedValues for the level those match.\n\nThere are two ways that we can match values in the hierarchy:\n1.",
+                    "default": "`HierarchyMatching.Full` - Only leaf levels are matched.\nUses the values array which exits only for the last level {@link DataViewMatrixNode.values }\n\n2. {@link `HierarchyMatching.Partial`} - Can match any specific level. Which works two different ways:\n\n- Getting the value from the subtotal if we match the whole hierarchy.\n\n- Getting the value from scoped values if match specific level {@link DataViewMatrixNode.nodeValues }.\n\n(Using {@link DataViewScopeWildcard }).",
+                    "type": "number",
+                    "anyOf": [
+                        {
+                            "const": 0,
+                            "description": "Only leaf levels are matched."
+                        },
+                        {
+                            "const": 1,
+                            "description": "All levels are matched."
+                        }
+                    ]
+                },
+                "order": {
+                    "description": "Specifies a user-defined ordering of identical properties.\nSelector constructors should strive to monitonically increase this number across identical properties differing by id.",
+                    "type": "number"
+                }
+            },
+            "additionalProperties": false
+        },
+        "DataRepetitionSelector": {
+            "type": "object",
+            "properties": {
+                "scopeId": {
+                    "description": "Defines the intersection of scopes. For example - product color = red.",
+                    "$ref": "../../semanticQuery/1.4.0/schema.json#/definitions/QueryExpressionContainer"
+                },
+                "wildcard": {
+                    "description": "Defines a match against all instances of a given DataView scope. Does not match Subtotals.\nDeprecated: - Use roles instead.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "../../semanticQuery/1.4.0/schema.json#/definitions/QueryExpressionContainer"
+                    }
+                },
+                "roles": {
+                    "description": "Matches against all fields in a role.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "total": {
+                    "description": "Matches against the totals and subtotals.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "../../semanticQuery/1.4.0/schema.json#/definitions/QueryExpressionContainer"
+                    }
+                },
+                "dataViewWildcard": {
+                    "description": "Matches all instances or all totals or both.",
+                    "$ref": "#/definitions/DataViewWildcard"
+                }
+            },
+            "additionalProperties": false
+        },
+        "DataViewWildcard": {
+            "type": "object",
+            "properties": {
+                "matchingOption": {
+                    "$ref": "#/definitions/DataViewWildcardMatchingOption",
+                    "description": "Defines the matching option to use."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "matchingOption"
+            ]
+        },
+        "DataViewWildcardMatchingOption": {
+            "type": "number",
+            "anyOf": [
+                {
+                    "const": 0,
+                    "description": "Match Identities and Totals (default)"
+                },
+                {
+                    "const": 1,
+                    "description": "Match Instances with Identities only"
+                },
+                {
+                    "const": 2,
+                    "description": "Match Totals only"
+                }
+            ]
+        }
+    }
+}

--- a/tests/fixtures/pbir_schemas/semanticQuery-1.4.0.schema.json
+++ b/tests/fixtures/pbir_schemas/semanticQuery-1.4.0.schema.json
@@ -1,0 +1,1920 @@
+{
+    "$id": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/semanticQuery/1.4.0/schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Semantic Query",
+    "description": "Defines shared definitions for queries and filters.",
+    "definitions": {
+        "FilterDefinition": {
+            "description": "Defines a filter element as a partial query structure",
+            "type": "object",
+            "properties": {
+                "Version": {
+                    "description": "Version of the query",
+                    "type": "number",
+                    "const": 2
+                },
+                "From": {
+                    "description": "Set of tables from which the data will be picked.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/EntitySource"
+                    }
+                },
+                "Where": {
+                    "description": "Set of filters to apply to the data.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryFilter"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "From",
+                "Where"
+            ]
+        },
+        "QueryFilter": {
+            "type": "object",
+            "properties": {
+                "Target": {
+                    "description": "Set of expressions over which the condition applies. Applied to the set of all non-aggregate, non-measure expressions in the Select if not specified.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryExpressionContainer"
+                    }
+                },
+                "Condition": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Condition to apply to the target. Must be an expression that evaluates to a boolean."
+                },
+                "Annotations": {
+                    "description": "Auxillary metadata for this filter.",
+                    "type": "object",
+                    "additionalProperties": {}
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Condition"
+            ]
+        },
+        "QueryExpressionContainer": {
+            "description": "Holds a single expression and associated metadata.\nName, NativeReferenceName, and Annotations may be specified for any expression.\nEach other property represents a specific type of expression and exactly one of these other properties must be specified.",
+            "type": "object",
+            "properties": {
+                "Name": {
+                    "description": "The name by which the expression can be referenced",
+                    "type": "string"
+                },
+                "NativeReferenceName": {
+                    "description": "The name by which the expression can be referenced in native expressions.",
+                    "type": "string"
+                },
+                "Annotations": {
+                    "description": "Auxiliary metadata for this expression.",
+                    "type": "object",
+                    "properties": {
+                        "customTotalMetadata": {
+                            "$ref": "#/definitions/QueryCustomTotalMetadata"
+                        }
+                    },
+                    "additionalProperties": {}
+                },
+                "SourceRef": {
+                    "description": "The SourceRef element contains an expression which is reference to a source table in the query or the data.",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/StandaloneSourceRefExpression"
+                        },
+                        {
+                            "$ref": "#/definitions/QuerySourceRefExpression"
+                        }
+                    ]
+                },
+                "Column": {
+                    "description": "The Column element contains an expression which is a reference to a column in a source table.",
+                    "$ref": "#/definitions/QueryColumnExpression"
+                },
+                "Measure": {
+                    "description": "The Measure element contains an expression which is a reference to a measure in a source table.",
+                    "$ref": "#/definitions/QueryMeasureExpression"
+                },
+                "Min": {
+                    "description": "The Min element contains an expression whose min aggregation needs to be computed.",
+                    "$ref": "#/definitions/QueryMinExpression"
+                },
+                "Max": {
+                    "description": "The Max element contains an expression whose max aggregation needs to be computed.",
+                    "$ref": "#/definitions/QueryMaxExpression"
+                },
+                "Aggregation": {
+                    "description": "The Aggregation element contains an expression which is an aggregation of an expression.",
+                    "$ref": "#/definitions/QueryAggregationExpression"
+                },
+                "Percentile": {
+                    "description": "The Percentile element contains an expression which computes a percentile of an expression.",
+                    "$ref": "#/definitions/QueryPercentileExpression"
+                },
+                "Hierarchy": {
+                    "description": "Hierarchy is an element which represents a reference to a hierarchy in a source table.",
+                    "$ref": "#/definitions/QueryHierarchyExpression"
+                },
+                "HierarchyLevel": {
+                    "description": "HierarchyLevel is an element which represents a reference to a hierarchy level in a hierarchy.",
+                    "$ref": "#/definitions/QueryHierarchyLevelExpression"
+                },
+                "PropertyVariationSource": {
+                    "description": "PropertyVariationSource is an element which represents a reference to a source of variations associated with a property.",
+                    "$ref": "#/definitions/QueryPropertyVariationSourceExpression"
+                },
+                "Subquery": {
+                    "description": "Subquery is an element which holds a query.",
+                    "$ref": "#/definitions/QuerySubqueryExpression"
+                },
+                "Discretize": {
+                    "description": "Transforms a continuous space of numerical values into a discrete space of numerical values.",
+                    "$ref": "#/definitions/QueryDiscretizeExpression"
+                },
+                "And": {
+                    "description": "The And element contains an expression which represents an \"and\" between two expressions that evaluate to a boolean value.",
+                    "$ref": "#/definitions/QueryBinaryExpression"
+                },
+                "Between": {
+                    "description": "The Between element contains an expression which is a comparison between an expression and two bounds.",
+                    "$ref": "#/definitions/QueryBetweenExpression"
+                },
+                "In": {
+                    "description": "The In element contains an expression which is a comparison between an ordered list of expressions and a set of ordered lists of values.\nIf the tuple defined in Expressions matches any tuple defined in Values, then In returns true.",
+                    "$ref": "#/definitions/QueryInExpression"
+                },
+                "Or": {
+                    "description": "The And element contains an expression which represents an \"or\" between two expressions that evaluate to a boolean value.",
+                    "$ref": "#/definitions/QueryBinaryExpression"
+                },
+                "Comparison": {
+                    "description": "The Comparison element contains an expression which is a comparison between two expressions.",
+                    "$ref": "#/definitions/QueryComparisonExpression"
+                },
+                "Not": {
+                    "description": "The Not element contains an expression which represents a \"not\" of an expression that evaluate to a boolean value.",
+                    "$ref": "#/definitions/QueryNotExpression"
+                },
+                "Contains": {
+                    "description": "The Contains element contains an expression which is a \"contains\" comparison between two expressions.\nThe operation is case insensitive and accent sensitive.",
+                    "$ref": "#/definitions/QueryContainsExpression"
+                },
+                "StartsWith": {
+                    "description": "The StartsWith element contains an expression which is a \"starts with\" comparison between two expressions.",
+                    "$ref": "#/definitions/QueryStartsWithExpression"
+                },
+                "Exists": {
+                    "description": "The Exists element contains an expression which represents confirming the existence of at least one instance of an expression.",
+                    "$ref": "#/definitions/QueryExistsExpression"
+                },
+                "Literal": {
+                    "description": "The Literal element contains an expression which is a literal value.",
+                    "$ref": "#/definitions/QueryLiteralExpression"
+                },
+                "DateSpan": {
+                    "description": "The DateSpan element contains an expression which is a datespan calculation of an expression.\nA DateSpan can be compared directly to a Date via Comparison or Between.",
+                    "$ref": "#/definitions/QueryDateSpanExpression"
+                },
+                "DateAdd": {
+                    "description": "The DateAdd element contains an expression which is a dateadd calculation of an expression.",
+                    "$ref": "#/definitions/QueryDateAddExpression"
+                },
+                "Now": {
+                    "description": "The Now element contains an expression which returns the current date and time.",
+                    "$ref": "#/definitions/QueryNowExpression"
+                },
+                "DefaultValue": {
+                    "description": "The DefaultValue element represents the model-defined default value for a column.\nIt may only be used as the Right expression in a Comparison expression with a ComparisonKind of Equal.",
+                    "$ref": "#/definitions/QueryDefaultValueExpression"
+                },
+                "AnyValue": {
+                    "description": "The AnyValue element represents a wildcard value that will match any value in a column.\nIt may only be used as the Right expression in a Comparison expression with a ComparisonKind of Equal.",
+                    "$ref": "#/definitions/QueryAnyValueExpression"
+                },
+                "Arithmetic": {
+                    "description": "The Arithmetic element contains an expression which is an arithmetic operation on two expressions.",
+                    "$ref": "#/definitions/QueryArithmeticExpression"
+                },
+                "Floor": {
+                    "description": "The Floor element represents an operation to round the specified expression toward zero to a multiple of the specified size.",
+                    "$ref": "#/definitions/QueryFloorExpression"
+                },
+                "ScopedEval": {
+                    "description": "ScopedEval is an element which evaluates an expression in a specified scope.",
+                    "$ref": "#/definitions/QueryScopedEvalExpression"
+                },
+                "FilteredEval": {
+                    "description": "The FilteredEval element contains a set of filters to apply to the measure.",
+                    "$ref": "#/definitions/QueryFilteredEvalExpression"
+                },
+                "TransformTableRef": {
+                    "description": "The TransformTableRef element contains an expression which is reference to a TransformTable in the query.",
+                    "$ref": "#/definitions/QueryTransformTableRefExpression"
+                },
+                "TransformOutputRoleRef": {
+                    "description": "The TransformOutputRoleRef element contains an expression which is reference to a column produced by a Transform algorithm.\nThe reference is resolved by the Role attached to the output column by the transform.",
+                    "$ref": "#/definitions/QueryTransformOutputRoleRefExpression"
+                },
+                "SparklineData": {
+                    "description": "Used to represent the data behind a sparkline. The data returned will be JSON formatted X/Y value pairs.",
+                    "$ref": "#/definitions/QuerySparklineDataExpression"
+                },
+                "NativeVisualCalculation": {
+                    "description": "The NativeVisualCalculation element represents invocation of an expression defined using an expression in an underlying query language.\nThe expression should be invoked in the Visual Calculation Context for this query.",
+                    "$ref": "#/definitions/QueryNativeVisualCalc"
+                },
+                "FillRule": {
+                    "description": "The FillRule element represents an operation to apply a dynamic fill operation.",
+                    "$ref": "#/definitions/QueryFillRuleExpression"
+                },
+                "GroupRef": {
+                    "description": "The GroupRef element contains an expression which is a reference to a model grouping column.",
+                    "$ref": "#/definitions/QueryGroupRefExpression"
+                },
+                "ResourcePackageItem": {
+                    "description": "The ResourcePackageItem element contains an expression which references a ResourcePackage item.",
+                    "$ref": "#/definitions/QueryResourcePackageItem"
+                },
+                "RoleRef": {
+                    "description": "The RoleRef element contains an expression which is a reference to a named Role defined by a Visual.",
+                    "$ref": "#/definitions/QueryRoleRefExpression"
+                },
+                "SummaryValueRef": {
+                    "description": "The SumaryValueRef element contains an expression which is a reference to a summary value in Insights Summary.",
+                    "$ref": "#/definitions/QuerySummaryValueRefExpression"
+                },
+                "AllRolesRef": {
+                    "description": "The AllRolesRef element is used to reference all the roles in a visual.",
+                    "$ref": "#/definitions/QueryAllRolesRefExpression"
+                },
+                "SelectRef": {
+                    "description": "The SelectRef element contains an expression which is a reference to a named item in the select clause of the query.",
+                    "$ref": "#/definitions/QuerySelectRefExpression"
+                },
+                "ThemeDataColor": {
+                    "description": "The ThemeDataColor element represents an operation to select a color from a theme.",
+                    "$ref": "#/definitions/QueryThemeDataColorExpression"
+                },
+                "Conditional": {
+                    "description": "The Conditional element represents an operation to select between several possible cases or an optional default.",
+                    "$ref": "#/definitions/QueryConditionalExpression"
+                },
+                "NativeMeasure": {
+                    "description": "The NativeMeasure element represents invocation of a measure defined using an expression in an underlying query language.",
+                    "$ref": "#/definitions/QueryNativeMeasure"
+                },
+                "NativeColumn": {
+                    "description": "The NativeColumn element represents invocation of a column defined using an expression in an underlying query language.",
+                    "$ref": "#/definitions/QueryNativeColumn"
+                },
+                "VisualTopN": {
+                    "description": "The VisualTopN element represents a type of filter that limits the amount of data points returned in a query",
+                    "$ref": "#/definitions/QueryVisualTopNExpression"
+                }
+            },
+            "additionalProperties": false,
+            "oneOf": [
+                {
+                    "required": [
+                        "SourceRef"
+                    ]
+                },
+                {
+                    "required": [
+                        "Column"
+                    ]
+                },
+                {
+                    "required": [
+                        "Measure"
+                    ]
+                },
+                {
+                    "required": [
+                        "Min"
+                    ]
+                },
+                {
+                    "required": [
+                        "Max"
+                    ]
+                },
+                {
+                    "required": [
+                        "Aggregation"
+                    ]
+                },
+                {
+                    "required": [
+                        "Percentile"
+                    ]
+                },
+                {
+                    "required": [
+                        "Hierarchy"
+                    ]
+                },
+                {
+                    "required": [
+                        "HierarchyLevel"
+                    ]
+                },
+                {
+                    "required": [
+                        "PropertyVariationSource"
+                    ]
+                },
+                {
+                    "required": [
+                        "Subquery"
+                    ]
+                },
+                {
+                    "required": [
+                        "Discretize"
+                    ]
+                },
+                {
+                    "required": [
+                        "And"
+                    ]
+                },
+                {
+                    "required": [
+                        "Between"
+                    ]
+                },
+                {
+                    "required": [
+                        "In"
+                    ]
+                },
+                {
+                    "required": [
+                        "Or"
+                    ]
+                },
+                {
+                    "required": [
+                        "Comparison"
+                    ]
+                },
+                {
+                    "required": [
+                        "Not"
+                    ]
+                },
+                {
+                    "required": [
+                        "Contains"
+                    ]
+                },
+                {
+                    "required": [
+                        "StartsWith"
+                    ]
+                },
+                {
+                    "required": [
+                        "Exists"
+                    ]
+                },
+                {
+                    "required": [
+                        "Literal"
+                    ]
+                },
+                {
+                    "required": [
+                        "DateSpan"
+                    ]
+                },
+                {
+                    "required": [
+                        "DateAdd"
+                    ]
+                },
+                {
+                    "required": [
+                        "Now"
+                    ]
+                },
+                {
+                    "required": [
+                        "DefaultValue"
+                    ]
+                },
+                {
+                    "required": [
+                        "AnyValue"
+                    ]
+                },
+                {
+                    "required": [
+                        "Arithmetic"
+                    ]
+                },
+                {
+                    "required": [
+                        "Floor"
+                    ]
+                },
+                {
+                    "required": [
+                        "ScopedEval"
+                    ]
+                },
+                {
+                    "required": [
+                        "FilteredEval"
+                    ]
+                },
+                {
+                    "required": [
+                        "TransformTableRef"
+                    ]
+                },
+                {
+                    "required": [
+                        "TransformOutputRoleRef"
+                    ]
+                },
+                {
+                    "required": [
+                        "SparklineData"
+                    ]
+                },
+                {
+                    "required": [
+                        "NativeVisualCalculation"
+                    ]
+                },
+                {
+                    "required": [
+                        "FillRule"
+                    ]
+                },
+                {
+                    "required": [
+                        "GroupRef"
+                    ]
+                },
+                {
+                    "required": [
+                        "ResourcePackageItem"
+                    ]
+                },
+                {
+                    "required": [
+                        "RoleRef"
+                    ]
+                },
+                {
+                    "required": [
+                        "SummaryValueRef"
+                    ]
+                },
+                {
+                    "required": [
+                        "AllRolesRef"
+                    ]
+                },
+                {
+                    "required": [
+                        "SelectRef"
+                    ]
+                },
+                {
+                    "required": [
+                        "ThemeDataColor"
+                    ]
+                },
+                {
+                    "required": [
+                        "Conditional"
+                    ]
+                },
+                {
+                    "required": [
+                        "NativeMeasure"
+                    ]
+                },
+                {
+                    "required": [
+                        "NativeColumn"
+                    ]
+                },
+                {
+                    "required": [
+                        "VisualTopN"
+                    ]
+                }
+            ]
+        },
+        "QueryVisualTopNExpression": {
+            "type": "object",
+            "properties": {
+                "ItemCount": {
+                    "type": "number"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "ItemCount"
+            ]
+        },
+        "QueryNativeColumn": {
+            "type": "object",
+            "properties": {
+                "DataType": {
+                    "description": "The expected result data type of the native expression.",
+                    "type": "number"
+                },
+                "Expression": {
+                    "description": "The expression to evaluate.",
+                    "type": "string"
+                },
+                "Language": {
+                    "description": "The name of the underlying query language used to define Expression.",
+                    "type": "string"
+                },
+                "Source": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Defines the table that this column should be considered as part of."
+                },
+                "ExpressionContentCache": {
+                    "description": "Holds metadata about the expression content.",
+                    "$ref": "#/definitions/QueryExpressionContentCache"
+                },
+                "ProposedName": {
+                    "description": "The preferred name that should be used if the expression needs to be associated with a name in order to be evaluated.",
+                    "type": "string"
+                },
+                "Format": {
+                    "description": "The format string that should be applied to the result of evaluating the expression.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "DataType",
+                "Expression",
+                "Language",
+                "Source"
+            ]
+        },
+        "QueryExpressionContentCache": {
+            "type": "object",
+            "properties": {
+                "Dependencies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryExpressionContainer"
+                    }
+                },
+                "UnrecognizedIdentifiers": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "QueryNativeMeasure": {
+            "type": "object",
+            "properties": {
+                "DataType": {
+                    "description": "The expected result data type of the native expression.",
+                    "type": "number"
+                },
+                "Expression": {
+                    "description": "The expression to evaluate.",
+                    "type": "string"
+                },
+                "Language": {
+                    "description": "The name of the underlying query language used to define Expression.",
+                    "type": "string",
+                    "const": "dax"
+                },
+                "ExpressionContentCache": {
+                    "description": "Holds metadata about the expression content.",
+                    "$ref": "#/definitions/QueryExpressionContentCache"
+                },
+                "ProposedName": {
+                    "description": "The preferred name that should be used if the expression needs to be associated with a name in order to be evaluated.",
+                    "type": "string"
+                },
+                "Format": {
+                    "description": "The format string that should be applied to the result of evaluating the expression.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "DataType",
+                "Expression",
+                "Language"
+            ]
+        },
+        "QueryConditionalExpression": {
+            "type": "object",
+            "properties": {
+                "Cases": {
+                    "description": "Cases are considered in the specified order.\nThe result is the Case.Value of the first case where Case.Condition evaluates to true.\nIf no Case.Condition evaluates to true, the result is the DefaultValue, if DefaultValue is specified.\nOtherwise, the result is null.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryCase"
+                    }
+                },
+                "DefaultValue": {
+                    "description": "An optional value to return when no case evaluates to true.",
+                    "$ref": "#/definitions/QueryExpressionContainer"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Cases"
+            ]
+        },
+        "QueryCase": {
+            "type": "object",
+            "properties": {
+                "Condition": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "An expression producing a boolean indicating whether or not to match this Case."
+                },
+                "Value": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "An expression producing the result when this case is matched."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Condition",
+                "Value"
+            ]
+        },
+        "QueryThemeDataColorExpression": {
+            "type": "object",
+            "properties": {
+                "ColorId": {
+                    "description": "The theme color to select.",
+                    "type": "number"
+                },
+                "Percent": {
+                    "type": "number"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "ColorId",
+                "Percent"
+            ]
+        },
+        "QuerySelectRefExpression": {
+            "type": "object",
+            "properties": {
+                "ExpressionName": {
+                    "description": "The Name of the ExpressionContainer from Select of the QueryDefinition.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "ExpressionName"
+            ]
+        },
+        "QueryAllRolesRefExpression": {
+            "type": "object",
+            "additionalProperties": false
+        },
+        "QuerySummaryValueRefExpression": {
+            "type": "object",
+            "properties": {
+                "Name": {
+                    "description": "The Name of the summary value within a summary template.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Name"
+            ]
+        },
+        "QueryRoleRefExpression": {
+            "type": "object",
+            "properties": {
+                "Role": {
+                    "description": "The Name of the desired Role within a Visual.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Role"
+            ]
+        },
+        "QueryResourcePackageItem": {
+            "type": "object",
+            "properties": {
+                "PackageName": {
+                    "description": "Identifies the ResourcePackage.",
+                    "type": "string"
+                },
+                "PackageType": {
+                    "description": "Identifies the type of resource package.",
+                    "type": "number"
+                },
+                "ItemName": {
+                    "description": "Identifies the item within the resource package",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "ItemName",
+                "PackageName",
+                "PackageType"
+            ]
+        },
+        "QueryGroupRefExpression": {
+            "type": "object",
+            "properties": {
+                "GroupedColumns": {
+                    "description": "The underlying columns for the desired grouping.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryExpressionContainer"
+                    }
+                },
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Reference to the source table containing the property. Must be a SourceRef, PropertyVariationSource, or TransformTableRef expression."
+                },
+                "Property": {
+                    "description": "The name of the target property in the source.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "GroupedColumns",
+                "Property"
+            ]
+        },
+        "QueryFillRuleExpression": {
+            "type": "object",
+            "properties": {
+                "Input": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "The expression providing the input value to the rule."
+                },
+                "FillRule": {
+                    "description": "Describes the algorithm, and associated parameters, needed to convert the Input into the desired fill."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "FillRule",
+                "Input"
+            ]
+        },
+        "QueryNativeVisualCalc": {
+            "type": "object",
+            "properties": {
+                "Language": {
+                    "description": "The name of the underlying query language that is used to define Expression (i.e., \"Dax\").",
+                    "type": "string",
+                    "const": "dax"
+                },
+                "Expression": {
+                    "description": "The expression to be evaluated.",
+                    "type": "string"
+                },
+                "Name": {
+                    "description": "The name of the calculation",
+                    "type": "string"
+                },
+                "DataType": {
+                    "description": "The data type of visual calculation",
+                    "enum": [
+                        "Binary",
+                        "Boolean",
+                        "Date",
+                        "DateTime",
+                        "DateTimeZone",
+                        "Decimal",
+                        "Double",
+                        "Duration",
+                        "Integer",
+                        "Json",
+                        "None",
+                        "Null",
+                        "Text",
+                        "Time",
+                        "Variant"
+                    ],
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "Language",
+                "Name"
+            ]
+        },
+        "QuerySparklineDataExpression": {
+            "type": "object",
+            "properties": {
+                "Measure": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "The measure to compute sparkline data for."
+                },
+                "Groupings": {
+                    "description": "The granularity at which to evaluate the measure.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryExpressionContainer"
+                    }
+                },
+                "PointsPerSparkline": {
+                    "description": "Number of points per sparkline",
+                    "type": "number",
+                    "const": 52
+                },
+                "ApplyCalculationGroupTo": {
+                    "description": "The granularity of the sparkline measure in the calculation group evaluation. This determines whether the\ncalculation group should apply to the entire sparkline or to each value of the sparkline. Defaults to entire\nsparkline (\"Sparkline\")",
+                    "default": "Sparkline",
+                    "type": "string",
+                    "anyOf": [
+                        {
+                            "const": "Sparkline"
+                        },
+                        {
+                            "const": "Point"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Groupings",
+                "Measure"
+            ]
+        },
+        "QueryTransformOutputRoleRefExpression": {
+            "type": "object",
+            "properties": {
+                "Role": {
+                    "description": "The Role of the target column.",
+                    "type": "string"
+                },
+                "Transform": {
+                    "description": "The Name of the target Transform. This must be omitted when used to define a column in the output table of a Transform.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Role"
+            ]
+        },
+        "QueryTransformTableRefExpression": {
+            "type": "object",
+            "properties": {
+                "Source": {
+                    "description": "The Name of the target table.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Source"
+            ]
+        },
+        "QueryFilteredEvalExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "The expression over which the condition applies. Must be a scalar."
+                },
+                "Filters": {
+                    "description": "List of filters to apply to the measure.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryFilter"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "Filters"
+            ]
+        },
+        "QueryScopedEvalExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Expression to evaluate in the new scope."
+                },
+                "Scope": {
+                    "description": "Set of expressions defining the new scope.  These expressions can only be Columns.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryExpressionContainer"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "Scope"
+            ]
+        },
+        "QueryFloorExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Expression to round"
+                },
+                "Size": {
+                    "description": "Describes the desired multiple for rounding.\n- TimeUnit is specified: the expression is rounded to a Size multiples of the specified TimeUnit.\n- TimeUnit is omitted: the expression is rounded to a multiple of Size.",
+                    "type": "number"
+                },
+                "TimeUnit": {
+                    "description": "The desired unit of rounding for Date/Time values.",
+                    "type": "number",
+                    "anyOf": [
+                        {
+                            "const": 0,
+                            "description": "Day"
+                        },
+                        {
+                            "const": 1,
+                            "description": "Week"
+                        },
+                        {
+                            "const": 2,
+                            "description": "Month"
+                        },
+                        {
+                            "const": 3,
+                            "description": "Year"
+                        },
+                        {
+                            "const": 4,
+                            "description": "Decade"
+                        },
+                        {
+                            "const": 5,
+                            "description": "Second"
+                        },
+                        {
+                            "const": 6,
+                            "description": "Minute"
+                        },
+                        {
+                            "const": 7,
+                            "description": "Hour"
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "Size"
+            ]
+        },
+        "QueryArithmeticExpression": {
+            "type": "object",
+            "properties": {
+                "Left": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "First operand expression"
+                },
+                "Right": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Second operand expression"
+                },
+                "Operator": {
+                    "$ref": "#/definitions/ArithmeticOperatorKind",
+                    "description": "The arithmetic operation to perform"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Left",
+                "Operator",
+                "Right"
+            ]
+        },
+        "ArithmeticOperatorKind": {
+            "type": "number",
+            "anyOf": [
+                {
+                    "const": 0,
+                    "description": "Add"
+                },
+                {
+                    "const": 1,
+                    "description": "Subtract"
+                },
+                {
+                    "const": 2,
+                    "description": "Multiple"
+                },
+                {
+                    "const": 3,
+                    "description": "Divide"
+                }
+            ]
+        },
+        "QueryAnyValueExpression": {
+            "type": "object",
+            "properties": {
+                "DefaultValueOverridesAncestors": {
+                    "description": "When true, any interaction with the a model-specified default value override results in all attribute relationship path ancestors being overridden.",
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false
+        },
+        "QueryDefaultValueExpression": {
+            "type": "object",
+            "additionalProperties": false
+        },
+        "QueryNowExpression": {
+            "type": "object",
+            "additionalProperties": false
+        },
+        "QueryDateAddExpression": {
+            "type": "object",
+            "properties": {
+                "Amount": {
+                    "description": "Number of units to add to the date.",
+                    "type": "number"
+                },
+                "TimeUnit": {
+                    "$ref": "#/definitions/TimeUnit",
+                    "description": "Unit of time to add to the date."
+                },
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Expression to which to add."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Amount",
+                "Expression",
+                "TimeUnit"
+            ]
+        },
+        "TimeUnit": {
+            "type": "number",
+            "anyOf": [
+                {
+                    "const": 0,
+                    "description": "Day"
+                },
+                {
+                    "const": 1,
+                    "description": "Week"
+                },
+                {
+                    "const": 2,
+                    "description": "Month"
+                },
+                {
+                    "const": 3,
+                    "description": "Year"
+                },
+                {
+                    "const": 4,
+                    "description": "Decade"
+                },
+                {
+                    "const": 5,
+                    "description": "Second"
+                },
+                {
+                    "const": 6,
+                    "description": "Minute"
+                },
+                {
+                    "const": 7,
+                    "description": "Hour"
+                }
+            ]
+        },
+        "QueryDateSpanExpression": {
+            "type": "object",
+            "properties": {
+                "TimeUnit": {
+                    "$ref": "#/definitions/TimeUnit",
+                    "description": "Unit of time used for datespan function."
+                },
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Expression to which to apply the datespan function."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "TimeUnit"
+            ]
+        },
+        "QueryLiteralExpression": {
+            "type": "object",
+            "properties": {
+                "Value": {
+                    "description": "The value of the literal.\n- Boolean: \"true\"\n- DateTime: \"datetime'YYYY-MM-DDThh:mm:ss.ffffff\"\n- Decimal: \"2.4M\"\n- Double: \"2.4D\"\n- Integer: \"24L\"\n- Number: \"\"\n- Null: \"null\"\n- String: \"some string value\"",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Value"
+            ]
+        },
+        "QueryExistsExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Expression to verify there exists at least one instance of. Must be a SourceRef expression."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression"
+            ]
+        },
+        "QueryStartsWithExpression": {
+            "type": "object",
+            "properties": {
+                "Left": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "First expression to which to apply the operator."
+                },
+                "Right": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Second expression to which to apply the operator."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Left",
+                "Right"
+            ]
+        },
+        "QueryContainsExpression": {
+            "type": "object",
+            "properties": {
+                "Left": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "First expression to which to apply the operator."
+                },
+                "Right": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Second expression to which to apply the operator."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Left",
+                "Right"
+            ]
+        },
+        "QueryNotExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Expression to negate. Must be an expression that evaluates to a boolean value."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression"
+            ]
+        },
+        "QueryComparisonExpression": {
+            "type": "object",
+            "properties": {
+                "ComparisonKind": {
+                    "$ref": "#/definitions/QueryComparisonKind",
+                    "description": "Type of the comparison."
+                },
+                "Left": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "First expression to which to apply the operator."
+                },
+                "Right": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Second expression to which to apply the operator."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "ComparisonKind",
+                "Left",
+                "Right"
+            ]
+        },
+        "QueryComparisonKind": {
+            "type": "number",
+            "anyOf": [
+                {
+                    "const": 0,
+                    "description": "Equal"
+                },
+                {
+                    "const": 1,
+                    "description": "GreaterThan"
+                },
+                {
+                    "const": 2,
+                    "description": "GreaterThanOrEqual"
+                },
+                {
+                    "const": 3,
+                    "description": "LessThan"
+                },
+                {
+                    "const": 4,
+                    "description": "LessThanOrEqual"
+                }
+            ]
+        },
+        "QueryBinaryExpression": {
+            "type": "object",
+            "properties": {
+                "Left": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "First expression to which to apply the operator."
+                },
+                "Right": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Second expression to which to apply the operator."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Left",
+                "Right"
+            ]
+        },
+        "QueryInExpression": {
+            "type": "object",
+            "properties": {
+                "Expressions": {
+                    "description": "The tuple of expressions to compare.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryExpressionContainer"
+                    }
+                },
+                "Values": {
+                    "description": "The tuples of values to compare with the expressions.",
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/QueryExpressionContainer"
+                        }
+                    }
+                },
+                "Table": {
+                    "description": "An expression, which must be a SourceRef, holding a table to compare against the Expressions.\nThe number of columns in the table must match the number of Expressions.\nEach row in the table is considered a tuple to be matched against the expressions.",
+                    "$ref": "#/definitions/QueryExpressionContainer"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expressions"
+            ]
+        },
+        "QueryBetweenExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Expression to compare."
+                },
+                "LowerBound": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Lower (inclusive) bound for the value of the expression."
+                },
+                "UpperBound": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Upper (inclusive) bound for the value of the expression."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "LowerBound",
+                "UpperBound"
+            ]
+        },
+        "QueryDiscretizeExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "The expression to be discretized."
+                },
+                "Count": {
+                    "description": "The number of discrete values to result from the transformation.",
+                    "type": "number"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Count",
+                "Expression"
+            ]
+        },
+        "QuerySubqueryExpression": {
+            "type": "object",
+            "properties": {
+                "Query": {
+                    "$ref": "#/definitions/QueryDefinition",
+                    "description": "The query to evaluate."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Query"
+            ]
+        },
+        "QueryDefinition": {
+            "description": "Defines a query to be executed.",
+            "type": "object",
+            "properties": {
+                "Version": {
+                    "description": "Version of the query",
+                    "type": "number",
+                    "const": 2
+                },
+                "From": {
+                    "description": "Set of tables from which the data will be picked.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/EntitySource"
+                    }
+                },
+                "Where": {
+                    "description": "Set of filters to apply to the data.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryFilter"
+                    }
+                },
+                "OrderBy": {
+                    "description": "List of expressions over which to sort the results.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QuerySortClause"
+                    }
+                },
+                "Select": {
+                    "description": "List of expressions to display in the results.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryExpressionContainer"
+                    }
+                },
+                "VisualShape": {
+                    "description": "Provides metadata information about the structure and state of the visualization.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Axis"
+                    }
+                },
+                "GroupBy": {
+                    "description": "List of expressions that represent the items to group by.\nThese additional groupings can be columns that we don't project or entity tables.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryExpressionContainer"
+                    }
+                },
+                "Transform": {
+                    "description": "List of table manipulation operations to apply within the query.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryTransform"
+                    }
+                },
+                "Top": {
+                    "description": "When specified, the query will return up to the specified number of rows based on the specified OrderBy.",
+                    "type": "number"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "From",
+                "Select"
+            ]
+        },
+        "QueryTransform": {
+            "type": "object",
+            "properties": {
+                "Name": {
+                    "description": "The name used to refer to this transform in other parts of the query.\nThis name must be unique across all other Transform.Name values in this query.",
+                    "type": "string"
+                },
+                "Algorithm": {
+                    "description": "The algorithm to apply.",
+                    "type": "string"
+                },
+                "Input": {
+                    "$ref": "#/definitions/QueryTransformInput",
+                    "description": "Describes the information needed to invoke the transform."
+                },
+                "Output": {
+                    "$ref": "#/definitions/QueryTransformOutput",
+                    "description": "Describes the expected results from the invoked transform."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Algorithm",
+                "Input",
+                "Name",
+                "Output"
+            ]
+        },
+        "QueryTransformOutput": {
+            "type": "object",
+            "properties": {
+                "Table": {
+                    "description": "The structure of the data produced by the transform.",
+                    "$ref": "#/definitions/QueryTransformTable"
+                }
+            },
+            "additionalProperties": false
+        },
+        "QueryTransformTable": {
+            "type": "object",
+            "properties": {
+                "Name": {
+                    "description": "Name by which the transform is referenced in the query.\nThis name must be unique across all other TransformTable.Name values in the query.",
+                    "type": "string"
+                },
+                "Columns": {
+                    "description": "The columns that make up this table.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryTransformTableColumn"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Columns",
+                "Name"
+            ]
+        },
+        "QueryTransformTableColumn": {
+            "type": "object",
+            "properties": {
+                "Role": {
+                    "description": "An arbitrary string used to identify this column to the transform algorithm.  Role may not be unique.",
+                    "type": "string"
+                },
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "The expression defining this column. ExpressionContainer.Name property defines the name of the column.\nExpressionContainer.Name is required and must be unique across all other columns in this table."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression"
+            ]
+        },
+        "QueryTransformInput": {
+            "type": "object",
+            "properties": {
+                "Parameters": {
+                    "description": "Parameters to be supplied when invoking the algorithm",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryExpressionContainer"
+                    }
+                },
+                "Table": {
+                    "description": "The structure of the table of data passed to the transform.",
+                    "$ref": "#/definitions/QueryTransformTable"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Parameters"
+            ]
+        },
+        "Axis": {
+            "type": "object",
+            "properties": {
+                "Groups": {
+                    "description": "Ordered list of hierarchical groupings in this axis.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AxisGroup"
+                    }
+                },
+                "Name": {
+                    "description": "Name by which the axis is referenced in the query.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Groups",
+                "Name"
+            ]
+        },
+        "AxisGroup": {
+            "type": "object",
+            "properties": {
+                "Keys": {
+                    "description": "List of expressions that define the keys of this group.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/QueryExpressionContainer"
+                    }
+                },
+                "Subtotal": {
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Keys",
+                "Subtotal"
+            ]
+        },
+        "QuerySortClause": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Expression over which to sort the results."
+                },
+                "Direction": {
+                    "$ref": "#/definitions/SortDirection",
+                    "description": "Indicates the direction to sort."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Direction",
+                "Expression"
+            ]
+        },
+        "SortDirection": {
+            "type": "number",
+            "anyOf": [
+                {
+                    "const": 1,
+                    "description": "Ascending"
+                },
+                {
+                    "const": 2,
+                    "description": "Descending"
+                }
+            ]
+        },
+        "EntitySource": {
+            "type": "object",
+            "properties": {
+                "Name": {
+                    "description": "Name by which the table is referenced in the query",
+                    "type": "string"
+                },
+                "Entity": {
+                    "description": "Reference name of the table in the data.",
+                    "type": "string"
+                },
+                "Schema": {
+                    "description": "Identifier for the schema which contains the entity source.  This can be omitted if the Schema name is the default.",
+                    "type": "string"
+                },
+                "Expression": {
+                    "description": "An expression that produces a table. Mandatory if Type is Expression.",
+                    "$ref": "#/definitions/QueryExpressionContainer"
+                },
+                "Type": {
+                    "description": "Type of entity source - defaults to Table (0)",
+                    "default": 0,
+                    "type": "number",
+                    "anyOf": [
+                        {
+                            "const": 0,
+                            "description": "The EntitySource is a reference to a table in the underlying model."
+                        },
+                        {
+                            "const": 1,
+                            "description": "The EntitySource is a presentation data object such as a report page or visual."
+                        },
+                        {
+                            "const": 2,
+                            "description": "The EntitySource is a table produced by the specified expression."
+                        }
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Name"
+            ]
+        },
+        "QueryPropertyVariationSourceExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Reference to the source property containing the property variation source. Must be a SourceRef expression."
+                },
+                "Name": {
+                    "description": "The name of the target variation source in the property.",
+                    "type": "string"
+                },
+                "Property": {
+                    "description": "The name of the target property in the SourceRef.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "Name",
+                "Property"
+            ]
+        },
+        "QueryHierarchyLevelExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Reference to the hierarchy containing the level. Must be a Hierarchy expression."
+                },
+                "Level": {
+                    "description": "The name of the target level in the hierarchy.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "Level"
+            ]
+        },
+        "QueryHierarchyExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Reference to the source table containing the hierarchy. Must be a SourceRef or a PropertyVariationSource expression."
+                },
+                "Hierarchy": {
+                    "description": "The name of the target hierarchy in the source.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "Hierarchy"
+            ]
+        },
+        "QueryPercentileExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "The expression to be evaluated for the percentile."
+                },
+                "K": {
+                    "description": "The desired percentile value.\n- Exclusive is true: K must be between 0 and 1, exclusive.\n- Exclusive is false: K must be between 0 and 1, inclusive.",
+                    "type": "number"
+                },
+                "Exclusive": {
+                    "description": "Indicates whether an inclusive or exclusive percentile should be computed.",
+                    "default": false,
+                    "type": "boolean"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "K"
+            ]
+        },
+        "QueryAggregationExpression": {
+            "type": "object",
+            "properties": {
+                "Function": {
+                    "$ref": "#/definitions/QueryAggregateFunction",
+                    "description": "Type of the aggregation."
+                },
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Expression to aggregate."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "Function"
+            ]
+        },
+        "QueryAggregateFunction": {
+            "type": "number",
+            "anyOf": [
+                {
+                    "const": 0,
+                    "description": "Sum"
+                },
+                {
+                    "const": 1,
+                    "description": "Average"
+                },
+                {
+                    "const": 2,
+                    "description": "Distinct count"
+                },
+                {
+                    "const": 3,
+                    "description": "Min"
+                },
+                {
+                    "const": 4,
+                    "description": "Max"
+                },
+                {
+                    "const": 5,
+                    "description": "Count number of non-null values"
+                },
+                {
+                    "const": 6,
+                    "description": "Median"
+                },
+                {
+                    "const": 7,
+                    "description": "StandardDeviation"
+                },
+                {
+                    "const": 8,
+                    "description": "Variance"
+                }
+            ]
+        },
+        "QueryMaxExpression": {
+            "type": "object",
+            "properties": {
+                "IncludeAllTypes": {
+                    "$ref": "#/definitions/IncludeAllTypes",
+                    "description": "Defines how variant types should be treated."
+                },
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Expression whose min will be computed."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "IncludeAllTypes"
+            ]
+        },
+        "IncludeAllTypes": {
+            "description": "Argument for QueryMinExpression and QueryMaxExpression to decide behavior for variant types.",
+            "type": "number",
+            "anyOf": [
+                {
+                    "const": 0,
+                    "description": "Exclude non-numeric types if the Expression returns mixed typed values."
+                },
+                {
+                    "const": 1,
+                    "description": "Include non-numeric types if the Expression returns mixed typed values if the model supports it. otherwise, fallback to Default behavior."
+                },
+                {
+                    "const": 2,
+                    "description": "Include non-numeric types if the Expression returns mixed typed value. raise an error if the model does not support this."
+                }
+            ]
+        },
+        "QueryMinExpression": {
+            "type": "object",
+            "properties": {
+                "IncludeAllTypes": {
+                    "$ref": "#/definitions/IncludeAllTypes",
+                    "description": "Defines how variant types should be treated."
+                },
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Expression whose min will be computed."
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "IncludeAllTypes"
+            ]
+        },
+        "QueryMeasureExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Reference to the source table containing the property. Must be a SourceRef, PropertyVariationSource, or TransformTableRef expression."
+                },
+                "Property": {
+                    "description": "The name of the target property in the source.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "Property"
+            ]
+        },
+        "QueryColumnExpression": {
+            "type": "object",
+            "properties": {
+                "Expression": {
+                    "$ref": "#/definitions/QueryExpressionContainer",
+                    "description": "Reference to the source table containing the property. Must be a SourceRef, PropertyVariationSource, or TransformTableRef expression."
+                },
+                "Property": {
+                    "description": "The name of the target property in the source.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Expression",
+                "Property"
+            ]
+        },
+        "QuerySourceRefExpression": {
+            "type": "object",
+            "properties": {
+                "Source": {
+                    "description": "Name of the source table in a query.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Source"
+            ]
+        },
+        "StandaloneSourceRefExpression": {
+            "type": "object",
+            "properties": {
+                "Schema": {
+                    "description": "The name of the schema containing the referenced entity - can be omitted if optional.",
+                    "type": "string"
+                },
+                "Entity": {
+                    "description": "Name of the referenced entity from your data.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "Entity"
+            ]
+        },
+        "QueryCustomTotalMetadata": {
+            "description": "Metadata for custom total calculations. Used to differentiate custom total calculations from normal visual calculations, enabling operations that need to identify which column a custom total belongs to.",
+            "type": "object",
+            "properties": {
+                "baseQueryName": {
+                    "description": "The query name of the base column that this custom total references. This establishes the relationship between a custom total and the column it refers to.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "baseQueryName"
+            ]
+        }
+    }
+}

--- a/tests/unit/test_commands_filter.py
+++ b/tests/unit/test_commands_filter.py
@@ -1,4 +1,8 @@
-"""Unit tests for pbi filter commands (PBIR file-based)."""
+"""Unit tests for pbi filter commands (PBIR file-based).
+
+Filters are written to the page's ``filterConfig`` using the official PBIR
+filterConfiguration schema. The previous flat shape is no longer produced.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +12,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
+from pbi_cli.backends import pbir_schemas as schemas
 from pbi_cli.cli import cli
 
 
@@ -22,13 +27,12 @@ def _make_fake_pbip(tmp_path: Path, page_name: str = "Page1") -> str:
     pages_dir = report_dir / "definition" / "pages"
     pages_dir.mkdir(parents=True)
 
-    # Create a page folder
     page_id = "aabbccdd1122"
     page_dir = pages_dir / page_id
     page_dir.mkdir()
 
     page_json = {
-        "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/2.1.0/schema.json",
+        "$schema": schemas.definition_schema("page"),
         "name": page_id,
         "displayName": page_name,
         "width": 1280,
@@ -36,21 +40,25 @@ def _make_fake_pbip(tmp_path: Path, page_name: str = "Page1") -> str:
     }
     (page_dir / "page.json").write_text(json.dumps(page_json), encoding="utf-8")
 
-    # pages.json order index
     pages_meta = {
-        "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/pagesMetadata/1.0.0/schema.json",
+        "$schema": schemas.definition_schema("pagesMetadata"),
         "pageOrder": [page_id],
         "activePageName": page_id,
     }
     (pages_dir / "pages.json").write_text(json.dumps(pages_meta), encoding="utf-8")
 
-    # .pbip manifest
     pbip_file = tmp_path / "TestReport.pbip"
     pbip_file.write_text(
         json.dumps({"version": "1.0", "artifacts": [{"report": {"path": "TestReport.Report"}}]}),
         encoding="utf-8",
     )
     return str(pbip_file)
+
+
+def _page_filters(tmp_path: Path) -> list[dict]:
+    page_dir = Path(tmp_path) / "TestReport.Report" / "definition" / "pages" / "aabbccdd1122"
+    data = json.loads((page_dir / "page.json").read_text(encoding="utf-8"))
+    return data.get("filterConfig", {}).get("filters", [])
 
 
 def _run(runner, *args):
@@ -71,12 +79,10 @@ class TestFilterList:
 
     def test_list_after_add_value_filter(self, runner, tmp_path):
         pbip = _make_fake_pbip(tmp_path)
-        # Add a value filter first
         _run(runner, "filter", "add-value",
              "--pbip", pbip, "--page", "Page1",
              "--table", "Sales", "--column", "Region",
              "--values", "UK,US")
-        # Now list should show filters
         result = _run(runner, "filter", "list", "--pbip", pbip, "--page", "Page1")
         assert result.exit_code == 0
 
@@ -92,18 +98,21 @@ class TestFilterAddRelativeDate:
         assert "Filter added" in result.output
 
     def test_add_relative_date_persisted(self, runner, tmp_path):
-        """Filter is written to the page.json file."""
+        """Filter is written under filterConfig with a valid FilterDefinition."""
         pbip = _make_fake_pbip(tmp_path)
         _run(runner, "filter", "add-relative-date",
              "--pbip", pbip, "--page", "Page1",
              "--table", "Calendar", "--column", "Date",
              "--last", "7", "--unit", "Weeks")
-        # Check file
-        page_dir = (Path(tmp_path) / "TestReport.Report" / "definition" / "pages" / "aabbccdd1122")
-        data = json.loads((page_dir / "page.json").read_text(encoding="utf-8"))
-        filters = data.get("filters", [])
+        filters = _page_filters(tmp_path)
         assert len(filters) == 1
         assert filters[0]["type"] == "RelativeDate"
+        # Real PBIR filter shape: name + FilterDefinition (Version/From/Where).
+        assert filters[0]["name"]
+        definition = filters[0]["filter"]
+        assert definition["Version"] == 2
+        assert definition["From"][0]["Entity"] == "Calendar"
+        assert "Where" in definition
 
     def test_add_relative_date_dry_run(self, runner, tmp_path):
         pbip = _make_fake_pbip(tmp_path)
@@ -117,44 +126,44 @@ class TestFilterAddRelativeDate:
         assert "DRY RUN" in result.output
 
 
-class TestFilterAddTopN:
-    def test_add_topn(self, runner, tmp_path):
+class TestFilterAddAdvanced:
+    def test_add_advanced_range(self, runner, tmp_path):
         pbip = _make_fake_pbip(tmp_path)
-        result = _run(runner, "filter", "add-topn",
+        result = _run(runner, "filter", "add-advanced",
                       "--pbip", pbip, "--page", "Page1",
-                      "--table", "Products", "--column", "Product",
-                      "--n", "10",
-                      "--by-table", "Sales", "--by-measure", "Total Revenue",
-                      "--direction", "Top")
+                      "--table", "financials", "--column", "Profit",
+                      "--condition", ">=:0", "--condition", "<=:1000000",
+                      "--logic", "And")
         assert result.exit_code == 0
         assert "Filter added" in result.output
 
-    def test_add_topn_persisted(self, runner, tmp_path):
+    def test_add_advanced_persisted(self, runner, tmp_path):
         pbip = _make_fake_pbip(tmp_path)
-        _run(runner, "filter", "add-topn",
+        _run(runner, "filter", "add-advanced",
              "--pbip", pbip, "--page", "Page1",
-             "--table", "Products", "--column", "Product",
-             "--n", "5",
-             "--by-table", "Sales", "--by-measure", "Total Revenue",
-             "--direction", "Bottom")
-        page_dir = (Path(tmp_path) / "TestReport.Report" / "definition" / "pages" / "aabbccdd1122")
-        data = json.loads((page_dir / "page.json").read_text(encoding="utf-8"))
-        filters = data.get("filters", [])
+             "--table", "financials", "--column", "Profit",
+             "--condition", ">=:1000")
+        filters = _page_filters(tmp_path)
         assert len(filters) == 1
-        assert filters[0]["type"] == "TopN"
-        assert filters[0]["operator"] == "BottomCount"
+        assert filters[0]["type"] == "Advanced"
+        where = filters[0]["filter"]["Where"][0]["Condition"]
+        assert "Comparison" in where
+        assert where["Comparison"]["ComparisonKind"] == 2  # >=
 
-    def test_add_topn_dry_run(self, runner, tmp_path):
+    def test_add_advanced_rejects_three_conditions(self, runner, tmp_path):
         pbip = _make_fake_pbip(tmp_path)
-        result = runner.invoke(cli, [
-            "--dry-run", "filter", "add-topn",
-            "--pbip", pbip, "--page", "Page1",
-            "--table", "Products", "--column", "Product",
-            "--n", "10",
-            "--by-table", "Sales", "--by-measure", "Total Revenue",
-        ])
-        assert result.exit_code == 0
-        assert "DRY RUN" in result.output
+        result = _run(runner, "filter", "add-advanced",
+                      "--pbip", pbip, "--page", "Page1",
+                      "--table", "f", "--column", "x",
+                      "--condition", ">:1", "--condition", "<:2", "--condition", "=:3")
+        assert result.exit_code != 0
+
+    def test_add_advanced_bad_condition(self, runner, tmp_path):
+        pbip = _make_fake_pbip(tmp_path)
+        result = _run(runner, "filter", "add-advanced",
+                      "--pbip", pbip, "--page", "Page1",
+                      "--table", "f", "--column", "x", "--condition", "notvalid")
+        assert result.exit_code != 0
 
 
 class TestFilterAddValue:
@@ -173,12 +182,21 @@ class TestFilterAddValue:
              "--pbip", pbip, "--page", "Page1",
              "--table", "Sales", "--column", "Segment",
              "--values", "Enterprise,Government")
-        page_dir = (Path(tmp_path) / "TestReport.Report" / "definition" / "pages" / "aabbccdd1122")
-        data = json.loads((page_dir / "page.json").read_text(encoding="utf-8"))
-        filters = data.get("filters", [])
+        filters = _page_filters(tmp_path)
         assert len(filters) == 1
-        assert filters[0]["type"] == "BasicFilter"
-        assert len(filters[0]["values"]) == 2
+        assert filters[0]["type"] == "Categorical"
+        in_expr = filters[0]["filter"]["Where"][0]["Condition"]["In"]
+        assert len(in_expr["Values"]) == 2
+
+    def test_add_value_exclude(self, runner, tmp_path):
+        pbip = _make_fake_pbip(tmp_path)
+        _run(runner, "filter", "add-value",
+             "--pbip", pbip, "--page", "Page1",
+             "--table", "Sales", "--column", "Region",
+             "--values", "UK", "--exclude")
+        filters = _page_filters(tmp_path)
+        assert filters[0]["type"] == "Exclude"
+        assert "Not" in filters[0]["filter"]["Where"][0]["Condition"]
 
     def test_add_value_dry_run(self, runner, tmp_path):
         pbip = _make_fake_pbip(tmp_path)
@@ -201,21 +219,16 @@ class TestFilterClear:
 
     def test_clear_removes_filters(self, runner, tmp_path):
         pbip = _make_fake_pbip(tmp_path)
-        # Add filters first
         _run(runner, "filter", "add-value",
              "--pbip", pbip, "--page", "Page1",
              "--table", "Sales", "--column", "Region", "--values", "UK")
         _run(runner, "filter", "add-value",
              "--pbip", pbip, "--page", "Page1",
              "--table", "Sales", "--column", "Segment", "--values", "Enterprise")
-        # Now clear
         result = _run(runner, "filter", "clear", "--pbip", pbip, "--page", "Page1")
         assert result.exit_code == 0
-        assert "2" in result.output  # "Cleared 2 filter(s)"
-        # Verify file state
-        page_dir = (Path(tmp_path) / "TestReport.Report" / "definition" / "pages" / "aabbccdd1122")
-        data = json.loads((page_dir / "page.json").read_text(encoding="utf-8"))
-        assert data.get("filters", []) == []
+        assert "2" in result.output
+        assert _page_filters(tmp_path) == []
 
     def test_clear_dry_run(self, runner, tmp_path):
         pbip = _make_fake_pbip(tmp_path)

--- a/tests/unit/test_filter_builder.py
+++ b/tests/unit/test_filter_builder.py
@@ -1,0 +1,154 @@
+"""Validate generated PBIR filters against Microsoft's *real* published schemas.
+
+The schemas under ``tests/fixtures/pbir_schemas/`` are vendored verbatim from
+https://github.com/microsoft/json-schemas (filterConfiguration 1.3.0 and its
+cross-file references semanticQuery 1.4.0 + formattingObjectDefinitions 1.5.0).
+Validating against them is the strongest guarantee that what we write is exactly
+what Power BI Desktop will accept — and it catches schema drift if the vendored
+copies are ever refreshed to a newer version.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pbi_cli.intelligence import filter_builder as fb
+
+jsonschema = pytest.importorskip("jsonschema")
+referencing = pytest.importorskip("referencing")
+
+_FIXTURES = Path(__file__).parent.parent / "fixtures" / "pbir_schemas"
+
+
+def _load(name: str) -> dict:
+    return json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def filter_validator():
+    """A Draft-07 validator for a single ``FilterContainer``, with refs resolved
+    offline from the vendored semanticQuery + formattingObjectDefinitions files.
+
+    We validate individual containers (not the whole ``filterConfig`` envelope):
+    when ``filterConfig`` is embedded in page.json, Power BI Desktop forbids the
+    ``$schema`` key that the standalone filterConfiguration schema marks required —
+    so the envelope can't satisfy the standalone schema, but each FilterContainer
+    can and must. See :func:`pbi_cli.intelligence.filter_builder.add_filter`.
+    """
+    from referencing import Registry, Resource
+
+    schemas = [
+        _load("filterConfiguration-1.3.0.schema.json"),
+        _load("semanticQuery-1.4.0.schema.json"),
+        _load("formattingObjectDefinitions-1.5.0.schema.json"),
+    ]
+    registry = Registry().with_resources(
+        [(s["$id"], Resource.from_contents(s)) for s in schemas]
+    )
+    container_ref = {"$ref": schemas[0]["$id"] + "#/definitions/FilterContainer"}
+    return jsonschema.Draft7Validator(container_ref, registry=registry)
+
+
+class TestSchemaValidation:
+    def test_value_filter_validates(self, filter_validator):
+        fc = fb.build_value_filter("financials", "Segment", ["Enterprise", "Government"])
+        filter_validator.validate(fc)
+
+    def test_exclude_filter_validates(self, filter_validator):
+        fc = fb.build_value_filter("financials", "Segment", ["Midmarket"], exclude=True)
+        filter_validator.validate(fc)
+
+    def test_advanced_single_validates(self, filter_validator):
+        fc = fb.build_advanced_filter("financials", "Profit", [(">=", 1000)])
+        filter_validator.validate(fc)
+
+    def test_advanced_range_validates(self, filter_validator):
+        fc = fb.build_advanced_filter(
+            "financials", "Profit", [(">=", 0), ("<=", 1_000_000)], logic="And"
+        )
+        filter_validator.validate(fc)
+
+    def test_advanced_measure_validates(self, filter_validator):
+        fc = fb.build_advanced_filter("Sales", "Total Sales", [(">", 0)], is_measure=True)
+        filter_validator.validate(fc)
+
+    def test_relative_date_validates(self, filter_validator):
+        fc = fb.build_relative_date_filter("Calendar", "Date", 30, "Days")
+        filter_validator.validate(fc)
+
+    def test_relative_date_exclude_today_validates(self, filter_validator):
+        fc = fb.build_relative_date_filter(
+            "Calendar", "Date", 6, "Months", include_today=False
+        )
+        filter_validator.validate(fc)
+
+    def test_locked_hidden_flags_validate(self, filter_validator):
+        fc = fb.build_value_filter(
+            "financials", "Country", ["USA"], locked=True, hidden=True
+        )
+        filter_validator.validate(fc)
+
+    def test_all_filters_in_a_config_validate(self, filter_validator):
+        cfg = fb.empty_filter_config()
+        fb.add_filter(cfg, fb.build_value_filter("f", "Country", ["USA"]))
+        fb.add_filter(cfg, fb.build_advanced_filter("f", "Profit", [(">=", 0)]))
+        fb.add_filter(cfg, fb.build_relative_date_filter("Calendar", "Date", 7, "Weeks"))
+        # Embedded filterConfig must NOT carry $schema (Desktop rejects it).
+        assert "$schema" not in cfg
+        for container in cfg["filters"]:
+            filter_validator.validate(container)
+
+
+class TestBuilderShapes:
+    def test_value_filter_shape(self):
+        fc = fb.build_value_filter("financials", "Segment", ["A", "B"])
+        assert fc["type"] == "Categorical"
+        assert fc["name"] and fb.is_valid_name(fc["name"])
+        definition = fc["filter"]
+        assert definition["Version"] == 2
+        assert definition["From"][0]["Entity"] == "financials"
+        in_expr = definition["Where"][0]["Condition"]["In"]
+        assert len(in_expr["Values"]) == 2
+
+    def test_exclude_negates(self):
+        fc = fb.build_value_filter("f", "x", ["v"], exclude=True)
+        assert fc["type"] == "Exclude"
+        assert "Not" in fc["filter"]["Where"][0]["Condition"]
+
+    def test_advanced_two_conditions_joined(self):
+        fc = fb.build_advanced_filter("f", "x", [(">=", 0), ("<=", 9)], logic="Or")
+        cond = fc["filter"]["Where"][0]["Condition"]
+        assert "Or" in cond
+        assert "Comparison" in cond["Or"]["Left"]
+
+    def test_advanced_rejects_too_many(self):
+        with pytest.raises(ValueError):
+            fb.build_advanced_filter("f", "x", [(">", 1), ("<", 2), ("=", 3)])
+
+    def test_advanced_rejects_bad_operator(self):
+        with pytest.raises(ValueError):
+            fb.build_advanced_filter("f", "x", [("!!", 1)])
+
+    def test_relative_date_rejects_nonpositive(self):
+        with pytest.raises(ValueError):
+            fb.build_relative_date_filter("c", "d", 0, "Days")
+
+    def test_relative_date_uses_dateadd_now(self):
+        fc = fb.build_relative_date_filter("Calendar", "Date", 30, "Days")
+        cond = fc["filter"]["Where"][0]["Condition"]
+        assert cond["Comparison"]["Right"]["DateAdd"]["Amount"] == -30
+        assert cond["Comparison"]["Right"]["DateAdd"]["Expression"] == {"Now": {}}
+
+    def test_embedded_config_has_no_schema_key(self):
+        cfg = fb.add_filter(None, fb.build_value_filter("f", "x", ["v"]))
+        # Desktop rejects $schema inside an embedded filterConfig.
+        assert "$schema" not in cfg
+        assert len(cfg["filters"]) == 1
+
+    def test_add_filter_strips_stray_schema(self):
+        cfg = {"$schema": "anything", "filters": []}
+        fb.add_filter(cfg, fb.build_value_filter("f", "x", ["v"]))
+        assert "$schema" not in cfg

--- a/tests/unit/test_pbir_rebind_format.py
+++ b/tests/unit/test_pbir_rebind_format.py
@@ -1,0 +1,164 @@
+"""Unit tests for the deeper rebind and generic formatting writers.
+
+Synthetic PBIR GA project in tmp_path — runs on any OS, no Desktop required.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pbi_cli.backends.pbir_backend import PbirBackend
+from pbi_cli.intelligence.visual_builder import (
+    AGG_SUM,
+    FieldDef,
+    VisualSpec,
+    build_bar_chart,
+)
+
+
+@pytest.fixture()
+def backend(tmp_path) -> PbirBackend:
+    report_dir = tmp_path / "Test.Report"
+    report_dir.mkdir()
+    return PbirBackend(str(tmp_path))
+
+
+def _add_bar(backend: PbirBackend, page: str) -> str:
+    spec = VisualSpec(
+        visual_type="barChart",
+        visual_body=build_bar_chart(
+            FieldDef(entity="financials", property="Country", agg=None),
+            FieldDef(entity="financials", property="Sales", agg=AGG_SUM),
+        ),
+        x=0, y=0, width=400, height=300, title="Bar",
+    )
+    return backend.visual_add(page, spec)["name"]
+
+
+def _visual_json(backend: PbirBackend, page: str, name: str) -> dict:
+    found = backend._ga_find_visual_json(page, name)  # type: ignore[attr-defined]
+    assert found
+    return found[1]
+
+
+# ── visual_rebind ───────────────────────────────────────────────────────────────
+
+
+class TestRebind:
+    def test_rebind_replaces_role(self, backend):
+        backend.page_add("P")
+        name = _add_bar(backend, "P")
+        ok = backend.visual_rebind(
+            "P", name, {"Y": [FieldDef(entity="financials", property="Profit", agg=AGG_SUM)]}
+        )
+        assert ok
+        qs = _visual_json(backend, "P", name)["visual"]["query"]["queryState"]
+        projs = qs["Y"]["projections"]
+        assert len(projs) == 1
+        assert "Profit" in projs[0]["queryRef"]
+        # Category preserved (not listed, clear_unlisted=False)
+        assert "Category" in qs
+
+    def test_rebind_multiple_fields_one_role(self, backend):
+        backend.page_add("P")
+        name = _add_bar(backend, "P")
+        backend.visual_rebind(
+            "P", name,
+            {"Y": [
+                FieldDef(entity="financials", property="Sales", agg=AGG_SUM),
+                FieldDef(entity="financials", property="Profit", agg=AGG_SUM),
+            ]},
+        )
+        qs = _visual_json(backend, "P", name)["visual"]["query"]["queryState"]
+        assert len(qs["Y"]["projections"]) == 2
+
+    def test_rebind_clear_unlisted(self, backend):
+        backend.page_add("P")
+        name = _add_bar(backend, "P")
+        backend.visual_rebind(
+            "P", name,
+            {"Category": [FieldDef(entity="financials", property="Segment", agg=None)]},
+            clear_unlisted=True,
+        )
+        qs = _visual_json(backend, "P", name)["visual"]["query"]["queryState"]
+        assert set(qs) == {"Category"}
+
+    def test_rebind_missing_visual_returns_false(self, backend):
+        backend.page_add("P")
+        assert backend.visual_rebind("P", "nope", {"Y": []}) is False
+
+    def test_rebind_empty_role_raises(self, backend):
+        backend.page_add("P")
+        name = _add_bar(backend, "P")
+        with pytest.raises(ValueError):
+            backend.visual_rebind("P", name, {"": [FieldDef(entity="t", property="c")]})
+
+
+# ── visual_set_format ───────────────────────────────────────────────────────────
+
+
+class TestSetFormat:
+    def test_set_bool_property(self, backend):
+        backend.page_add("P")
+        name = _add_bar(backend, "P")
+        ok = backend.visual_set_format("P", name, "dataLabels", "show", True, value_type="bool")
+        assert ok
+        objects = _visual_json(backend, "P", name)["visual"]["objects"]
+        expr = objects["dataLabels"][0]["properties"]["show"]["expr"]
+        assert expr["Literal"]["Value"] == "true"
+
+    def test_set_text_property(self, backend):
+        backend.page_add("P")
+        name = _add_bar(backend, "P")
+        backend.visual_set_format("P", name, "legend", "position", "Top", value_type="text")
+        objects = _visual_json(backend, "P", name)["visual"]["objects"]
+        assert objects["legend"][0]["properties"]["position"]["expr"]["Literal"]["Value"] == "'Top'"
+
+    def test_set_color_property(self, backend):
+        backend.page_add("P")
+        name = _add_bar(backend, "P")
+        backend.visual_set_format(
+            "P", name, "background", "color", "#F5F5F5", value_type="color", container_level=True
+        )
+        vco = _visual_json(backend, "P", name)["visual"]["visualContainerObjects"]
+        solid = vco["background"][0]["properties"]["color"]["solid"]
+        assert solid["color"]["expr"]["Literal"]["Value"] == "'#F5F5F5'"
+
+    def test_set_number_property(self, backend):
+        backend.page_add("P")
+        name = _add_bar(backend, "P")
+        backend.visual_set_format("P", name, "general", "transparency", 50, value_type="number")
+        objects = _visual_json(backend, "P", name)["visual"]["objects"]
+        prop = objects["general"][0]["properties"]["transparency"]
+        assert prop["expr"]["Literal"]["Value"] == "50D"
+
+    def test_auto_detects_color(self, backend):
+        backend.page_add("P")
+        name = _add_bar(backend, "P")
+        backend.visual_set_format("P", name, "background", "color", "#ABCDEF")
+        objects = _visual_json(backend, "P", name)["visual"]["objects"]
+        assert "solid" in objects["background"][0]["properties"]["color"]
+
+    def test_repeated_calls_merge_into_one_entry(self, backend):
+        backend.page_add("P")
+        name = _add_bar(backend, "P")
+        backend.visual_set_format("P", name, "legend", "show", True, value_type="bool")
+        backend.visual_set_format("P", name, "legend", "position", "Bottom", value_type="text")
+        objects = _visual_json(backend, "P", name)["visual"]["objects"]
+        assert len(objects["legend"]) == 1
+        assert set(objects["legend"][0]["properties"]) == {"show", "position"}
+
+    def test_missing_visual_returns_false(self, backend):
+        backend.page_add("P")
+        assert backend.visual_set_format("P", "nope", "legend", "show", True) is False
+
+    def test_round_trips_as_valid_json(self, backend):
+        backend.page_add("P")
+        name = _add_bar(backend, "P")
+        backend.visual_set_format("P", name, "legend", "position", "Top")
+        found = backend._ga_find_visual_json("P", name)  # type: ignore[attr-defined]
+        # Re-read from disk to confirm it serialised cleanly.
+        data = json.loads(found[0].read_text(encoding="utf-8"))
+        assert data["visual"]["objects"]["legend"]

--- a/tests/unit/test_pbir_schemas.py
+++ b/tests/unit/test_pbir_schemas.py
@@ -1,0 +1,58 @@
+"""Tests for the centralised PBIR schema-version registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from pbi_cli.backends import pbir_schemas as schemas
+
+
+def test_definition_schema_builds_expected_url():
+    url = schemas.definition_schema("visualContainer")
+    assert url == (
+        "https://developer.microsoft.com/json-schemas/fabric/item/report/"
+        "definition/visualContainer/2.9.0/schema.json"
+    )
+
+
+def test_item_schema_builds_expected_url():
+    url = schemas.item_schema("definitionProperties")
+    assert url.endswith("report/definitionProperties/2.0.0/schema.json")
+
+
+def test_unknown_definition_schema_raises():
+    with pytest.raises(KeyError):
+        schemas.definition_schema("doesNotExist")
+
+
+def test_unknown_item_schema_raises():
+    with pytest.raises(KeyError):
+        schemas.item_schema("doesNotExist")
+
+
+@pytest.mark.parametrize("name", list(schemas.DEFINITION_SCHEMA_VERSIONS))
+def test_all_registered_definition_schemas_resolve(name):
+    url = schemas.definition_schema(name)
+    assert url.startswith("https://developer.microsoft.com/json-schemas/")
+    assert url.endswith("/schema.json")
+    # version segment is present and looks like x.y.z
+    version = schemas.DEFINITION_SCHEMA_VERSIONS[name]
+    assert version.count(".") == 2
+    assert f"/{name}/{version}/" in url
+
+
+def test_backend_and_builder_use_the_registry():
+    """Backend constants and the visual builder schema come from the registry, so
+    a version bump here propagates everywhere."""
+    from pbi_cli.backends.pbir_backend import PbirBackend
+    from pbi_cli.intelligence.visual_builder import VISUAL_CONTAINER_SCHEMA
+
+    assert VISUAL_CONTAINER_SCHEMA == schemas.definition_schema("visualContainer")
+    assert PbirBackend.MOBILE_STATE_SCHEMA == schemas.definition_schema(
+        "visualContainerMobileState"
+    )
+
+
+def test_report_version_at_import_present():
+    rvi = schemas.REPORT_VERSION_AT_IMPORT
+    assert set(rvi) == {"visual", "report", "page"}


### PR DESCRIPTION
## Summary
Closes the maintainability and correctness gaps in the PBIR report layer, grounded in Microsoft's published schemas ([microsoft/json-schemas](https://github.com/microsoft/json-schemas/tree/main/fabric/item/report)) and **verified live in Power BI Desktop** (opens without errors; filters, rebind, formatting and a new 2.9.0 visual all render).

## Changes
- **Schema-version registry** (`backends/pbir_schemas.py`) — single source of truth for every PBIR `$schema` URL, pinned to the latest published versions. `pbir_backend`, `visual_builder`, `project_scaffold` resolve through it. Bumped visualContainer `2.7.0→2.9.0`, report `3.2.0→3.3.0`, pagesMetadata `1.0.0→1.1.0`; fixed `visualContainerMobileState` `2.5.0` (never existed) → `2.4.0`. `scripts/check_pbir_schemas.py` detects drift vs the live repo.
- **Filters rewritten to the real schema** — page filters now write a valid `filterConfig` with `FilterContainer` + `FilterDefinition` (`Version`/`From`/`Where`) bodies. New `intelligence/filter_builder.py` builds Categorical/Exclude, Advanced, and RelativeDate filters, validated in CI against vendored Microsoft schemas. Added `--exclude`, `add-advanced`, `--locked`/`--hidden`. **Removed `add-topn`** (no representation in `FilterDefinition`). Desktop-only fix: an embedded `filterConfig` must omit `$schema` — caught by live testing.
- **`visual set-format`** — generic formatting-object writer (data labels, legend, background, axis titles…), `objects` or `visualContainerObjects`.
- **`visual rebind`** — atomic multi-role rebind preserving position/title/formatting; builds all projections before writing.

## Testing
- **1079 tests pass**; ruff clean. New suites: schema registry, schema-validated filters (against vendored MS schemas), rebind/format.
- Verified end-to-end in Power BI Desktop on a real report — see updated ADR-003.

## Docs
- CHANGELOG + ADR-003 updated: schema-drift policy, filter format, embedded-`$schema` quirk, live-preview limitation.

### Breaking
- `pbi filter add-topn` removed (emitted invalid JSON; TopN belongs at the visual level — future work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)