### PR TITLE
feat(pbir): validation, field parameters, filter scope, duplication, AI visuals + filter field fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,49 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed — filter field must reference Entity, not a query alias
+- **Filter `field` now uses `SourceRef.Entity` (the table), not `SourceRef.Source` (a
+  query alias).** A `FilterContainer.field` built with an alias is accepted by the
+  published filterConfiguration schema *and* loads on first open, but Power BI Desktop
+  cannot resolve the alias at report/visual scope and **rewrites it to an empty
+  SourceRef on its next save**, which then blocks the report from opening ("Required
+  property 'Entity'/'Source' was not included … invalid value"). Verified live in
+  Desktop. The `Where`/`From` body still uses the alias (correct there). `pbi report
+  validate` gained `pbir.filter-field-alias` (warning) for alias-based fields and
+  already flags empty SourceRefs via `pbir.filter-field-sourceref` (error) — so it now
+  catches both classes *before* Desktop does.
+
+### Added — PBIR maturity: validation, field parameters, filter scope, duplication, AI visuals
+- **`pbi report validate`** — offline structural + referential PBIR validator. Encodes
+  the runtime-validator rules Power BI Desktop enforces at *reload* (e.g. no `$schema`
+  inside an embedded `filterConfig`) plus cross-file integrity checks (`pageOrder`,
+  `bookmarks.json` items/children, `parentGroupName`, `visualInteractions`
+  source/target) and schema-version drift against the registry. `--fail-on` makes it a
+  CI gate. New module `pbi_cli.pbir_validate`.
+- **Field parameters** — `pbi model field-parameter` generates the model-side calculated
+  table (label / Fields / Order columns + `NAMEOF` constructor partition + the
+  `ParameterMetadata` extended property) and registers it in `model.tmdl`. New module
+  `pbi_cli.intelligence.field_parameter`.
+- **Filter scope** — `pbi filter` now takes `--scope page|report|visual`. Report-level
+  filters write to `definition/report.json`; visual-level filters to the visual's
+  `visual.json` (with `--visual`). Page scope remains the default.
+- **Page / visual duplication** — `pbi report page-duplicate` (regenerates page + visual
+  ids and remaps group / interaction references so the copy is fully independent),
+  `pbi visual clone` (same page with offset, or to another page), `pbi visual move`
+  (keeps id, scrubs now-dangling interactions).
+- **AI visuals wired up** — `decomptree` and `keyinfluencers` now build proper
+  Analyze/Explain role bindings; `smartnarrative` and `qanda` add cleanly. Previously
+  these types were in the type map but errored on add.
+- **Button actions** — `pbi visual action` wires a button/shape to a `visualLink`
+  action: `PageNavigation` (resolves page display name → GUID), `Bookmark` (resolves
+  display name → id), `WebUrl`, `Back`, `Drill`, `QnA`. Buttons added with
+  `add-element` are no longer inert.
+- **`pbi visual get`** — read-side introspection of a visual: type, position, role
+  bindings, formatting objects, conditional formatting, filters, action, sync group,
+  group membership, mobile layout.
+- **Reference lines** — `pbi visual reference-line` adds a constant Y target line
+  (value, label, colour, style) to cartesian charts.
+
 ### Added — PBIR hardening: schema registry, correct filters, generic formatting, atomic rebind
 - **Schema-version registry** (`pbi_cli.backends.pbir_schemas`) — single source of
   truth for every PBIR `$schema` URL, populated from the latest *published* versions

--- a/src/pbi_cli/backends/pbir_backend.py
+++ b/src/pbi_cli/backends/pbir_backend.py
@@ -278,6 +278,63 @@ class PbirBackend:
             )
         return results
 
+    def visual_get(self, page: str, visual_name: str) -> dict[str, Any] | None:
+        """Introspect a visual: bindings, formatting, conditional formatting, filters.
+
+        Reads the visual.json back into a structured summary — the read-side
+        counterpart to the add/rebind/format writers. PBIR GA only. Returns None
+        if the visual is not found.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("visual_get requires PBIR GA format (definition/ folder).")
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return None
+        vj, data = found
+        visual = data.get("visual", {})
+
+        # Role → field queryRefs.
+        bindings: dict[str, list[str]] = {}
+        for role, role_data in visual.get("query", {}).get("queryState", {}).items():
+            refs = [p.get("queryRef", "") for p in role_data.get("projections", [])]
+            if refs:
+                bindings[role] = refs
+
+        # Conditional formatting: which properties target which field.
+        cond_fmt: list[dict[str, str]] = []
+        for entry in visual.get("objects", {}).get("values", []):
+            field = entry.get("selector", {}).get("metadata", "")
+            for prop in entry.get("properties", {}):
+                cond_fmt.append({"field": field, "property": prop})
+
+        # Button action, if any.
+        action = None
+        for link in visual.get("visualContainerObjects", {}).get("visualLink", []):
+            lit = link.get("properties", {}).get("type", {}).get("expr", {}).get("Literal", {})
+            if lit.get("Value"):
+                action = str(lit["Value"]).strip("'")
+
+        vtype = visual.get("visualType", "")
+        if not vtype and "visualGroup" in data:
+            vtype = "group"
+
+        return {
+            "name": data.get("name", vj.parent.name),
+            "visualType": vtype,
+            "position": data.get("position", {}),
+            "bindings": bindings,
+            "formattingObjects": sorted(visual.get("objects", {}).keys()),
+            "containerObjects": sorted(visual.get("visualContainerObjects", {}).keys()),
+            "conditionalFormatting": cond_fmt,
+            "filters": len(data.get("filterConfig", {}).get("filters", [])),
+            "isHidden": bool(data.get("isHidden")),
+            "parentGroupName": data.get("parentGroupName"),
+            "syncGroup": visual.get("syncGroup"),
+            "action": action,
+            "hasMobileLayout": (vj.parent / "mobile.json").exists(),
+        }
+
     def _ga_visual_add(self, page: str, spec: Any) -> dict[str, Any]:
         from pbi_cli.intelligence.visual_builder import spec_to_pbir_visual
 
@@ -324,6 +381,152 @@ class PbirBackend:
         rj = self._report_dir / "definition" / "report.json"
         rj.parent.mkdir(parents=True, exist_ok=True)
         rj.write_text(json.dumps(report_json, indent=2), encoding="utf-8")
+
+    # ── Page / visual duplication & move (PBIR GA) ─────────────────────────────
+    # Folder-per-object makes copy cheap, but ids must stay unique: a duplicated
+    # page gets a fresh page id AND fresh visual ids (with parentGroupName and
+    # page visualInteractions remapped), so the copy is fully independent.
+
+    def page_duplicate(self, display_name: str, new_display_name: str | None = None) -> dict[str, Any]:  # noqa: E501
+        """Duplicate a page (and all its visuals) under a new id. PBIR GA only.
+
+        Visual ids are regenerated and every internal reference (parentGroupName,
+        visualInteractions source/target) is remapped so the new page does not
+        alias the original. Returns the new page's {name, displayName}.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Page duplication requires PBIR GA format (definition/ folder).")
+        src_dir = self._ga_find_page_dir(display_name)
+        if not src_dir:
+            raise ValueError(f"Page '{display_name}' not found.")
+
+        new_page_id = uuid.uuid4().hex
+        dst_dir = self._ga_pages_dir() / new_page_id
+        shutil.copytree(src_dir, dst_dir)
+
+        # Rewrite page.json identity.
+        pj = dst_dir / "page.json"
+        page_data = json.loads(pj.read_text(encoding="utf-8"))
+        page_data["name"] = new_page_id
+        page_data["displayName"] = new_display_name or f"{display_name} (copy)"
+
+        # Regenerate visual ids and build an old→new map.
+        vd = dst_dir / "visuals"
+        id_map: dict[str, str] = {}
+        visual_dirs: list[Path] = []
+        if vd.is_dir():
+            for vdir in [d for d in vd.iterdir() if d.is_dir()]:
+                vj = vdir / "visual.json"
+                if not vj.exists():
+                    continue
+                old = json.loads(vj.read_text(encoding="utf-8")).get("name", vdir.name)
+                id_map[old] = uuid.uuid4().hex[:20]
+                visual_dirs.append(vdir)
+            for vdir in visual_dirs:
+                vj = vdir / "visual.json"
+                data = json.loads(vj.read_text(encoding="utf-8"))
+                old = data.get("name", vdir.name)
+                new = id_map[old]
+                data["name"] = new
+                if data.get("parentGroupName") in id_map:
+                    data["parentGroupName"] = id_map[data["parentGroupName"]]
+                vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+                vdir.rename(vdir.parent / new)
+
+        # Remap page-level visualInteractions to the new visual ids.
+        for inter in page_data.get("visualInteractions", []):
+            for slot in ("source", "target"):
+                if inter.get(slot) in id_map:
+                    inter[slot] = id_map[inter[slot]]
+        pj.write_text(json.dumps(page_data, indent=2), encoding="utf-8")
+
+        meta = self._ga_read_pages_json()
+        meta.setdefault("pageOrder", []).append(new_page_id)
+        self._ga_write_pages_json(meta)
+
+        return {"name": new_page_id, "displayName": page_data["displayName"],
+                "visuals": len(id_map)}
+
+    def visual_clone(
+        self,
+        page: str,
+        visual_name: str,
+        target_page: str | None = None,
+        *,
+        dx: int = 24,
+        dy: int = 24,
+    ) -> dict[str, Any] | None:
+        """Clone a visual under a fresh id, on the same page or another page.
+
+        The clone is offset by (dx, dy) when staying on the same page, and never
+        inherits group membership. PBIR GA only. Returns the new {name, page} or
+        None if the source visual was not found.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Visual clone requires PBIR GA format (definition/ folder).")
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return None
+        src_vj, _ = found
+        dest_page = target_page or page
+        dest_vd = self._ga_visuals_dir(dest_page)
+        if dest_vd is None:
+            raise ValueError(f"Target page '{dest_page}' not found.")
+
+        new_name = uuid.uuid4().hex[:20]
+        dst_dir = dest_vd / new_name
+        shutil.copytree(src_vj.parent, dst_dir)
+
+        vj = dst_dir / "visual.json"
+        data = json.loads(vj.read_text(encoding="utf-8"))
+        data["name"] = new_name
+        data.pop("parentGroupName", None)  # never auto-join a group
+        if target_page is None:
+            pos = data.setdefault("position", {})
+            pos["x"] = pos.get("x", 0) + dx
+            pos["y"] = pos.get("y", 0) + dy
+        vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return {"name": new_name, "page": dest_page}
+
+    def visual_move(self, page: str, visual_name: str, target_page: str) -> dict[str, Any] | None:
+        """Move a visual to another page, keeping its id. PBIR GA only.
+
+        Drops group membership and removes any visualInteractions on the source
+        page that referenced it (they would otherwise dangle). Returns
+        {name, page} or None if the source visual was not found.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Visual move requires PBIR GA format (definition/ folder).")
+        if target_page == page:
+            raise ValueError("Source and target page are the same.")
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return None
+        src_vj, data = found
+        dest_vd = self._ga_visuals_dir(target_page)
+        if dest_vd is None:
+            raise ValueError(f"Target page '{target_page}' not found.")
+
+        name = data.get("name", src_vj.parent.name)
+        data.pop("parentGroupName", None)
+        src_vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        shutil.move(str(src_vj.parent), str(dest_vd / src_vj.parent.name))
+
+        # Scrub dangling interactions on the source page.
+        src_page_dir = self._ga_find_page_dir(page)
+        if src_page_dir:
+            pj = src_page_dir / "page.json"
+            pdata = json.loads(pj.read_text(encoding="utf-8"))
+            inters = pdata.get("visualInteractions")
+            if inters:
+                pdata["visualInteractions"] = [
+                    i for i in inters if name not in (i.get("source"), i.get("target"))
+                ]
+                pj.write_text(json.dumps(pdata, indent=2), encoding="utf-8")
+        return {"name": name, "page": target_page}
 
     # ── Old PBIP implementation ────────────────────────────────────────────────
 
@@ -1192,6 +1395,54 @@ class PbirBackend:
         vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
         return True
 
+    # ── Analytics: constant reference line ─────────────────────────────────────
+    # A constant line lives under visual.objects.referenceLine as a list entry with
+    # its own selector id and properties (show/value/lineColor/style/displayName).
+    # Each call adds one line; ids keep multiple lines distinct.
+
+    def visual_add_reference_line(
+        self,
+        page: str,
+        visual_name: str,
+        value: float,
+        *,
+        name: str = "Target",
+        color: str = "#E81123",
+        style: str = "dashed",
+        show_label: bool = True,
+    ) -> bool:
+        """Add a constant Y reference line to a cartesian chart. PBIR GA only.
+
+        style: 'solid' | 'dashed' | 'dotted'. Returns True if found and updated.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Reference lines require PBIR GA format (definition/ folder).")
+        if style not in ("solid", "dashed", "dotted"):
+            raise ValueError("style must be 'solid', 'dashed' or 'dotted'")
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return False
+        vj, data = found
+
+        entry = {
+            "selector": {"id": uuid.uuid4().hex[:20]},
+            "properties": {
+                "show": {"expr": {"Literal": {"Value": "true"}}},
+                "displayName": {"expr": {"Literal": {"Value": f"'{name}'"}}},
+                "value": {"expr": {"Literal": {"Value": self._num_literal(value)}}},
+                "lineColor": {"solid": {"color": {"expr": {"Literal": {"Value": f"'{color}'"}}}}},
+                "style": {"expr": {"Literal": {"Value": f"'{style}'"}}},
+                "dataLabelShow": {
+                    "expr": {"Literal": {"Value": "true" if show_label else "false"}}
+                },
+            },
+        }
+        objects = data.setdefault("visual", {}).setdefault("objects", {})
+        objects.setdefault("referenceLine", []).append(entry)
+        vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return True
+
     # ── Visual field rebinding ─────────────────────────────────────────────────
 
     def visual_set_field(
@@ -1607,6 +1858,65 @@ class PbirBackend:
 
         return {"name": group_id, "displayName": group_display,
                 "members": [m[1].get("name") for m in members]}
+
+    # ── Button / shape actions ─────────────────────────────────────────────────
+    # A button's action is a `visualLink` entry under visualContainerObjects
+    # (the GA home for the legacy vcObjects.visualLink). `type` selects the action
+    # and the target property depends on it: PageNavigation→navigationSection
+    # (page GUID), Bookmark→bookmark (bookmark id), WebUrl→webUrl. Back / Drill /
+    # QnA need no target.
+
+    ACTION_TYPES = ("Back", "PageNavigation", "Bookmark", "Drill", "QnA", "WebUrl")
+
+    def visual_set_action(
+        self, page: str, visual_name: str, action_type: str, target: str | None = None
+    ) -> bool:
+        """Wire a navigation/action onto a button (or shape) visual. PBIR GA only.
+
+        For PageNavigation, ``target`` is a page display name or GUID; for Bookmark
+        it is a bookmark display name or id; for WebUrl it is the URL. Back/Drill/
+        QnA ignore ``target``. Returns True if the visual was found and updated.
+        """
+        self._require_load()
+        if self._format != "pbir_ga":
+            raise RuntimeError("Button actions require PBIR GA format (definition/ folder).")
+        if action_type not in self.ACTION_TYPES:
+            raise ValueError(f"type must be one of {self.ACTION_TYPES}")
+        found = self._ga_find_visual_json(page, visual_name)
+        if not found:
+            return False
+        vj, data = found
+
+        props: dict[str, Any] = {
+            "type": {"expr": {"Literal": {"Value": f"'{action_type}'"}}}
+        }
+        if action_type == "PageNavigation":
+            if not target:
+                raise ValueError("PageNavigation needs a target page.")
+            page_id = next(
+                (p["name"] for p in self.page_list()
+                 if target in (p["displayName"], p["name"])),
+                target,
+            )
+            props["navigationSection"] = {"expr": {"Literal": {"Value": f"'{page_id}'"}}}
+        elif action_type == "Bookmark":
+            if not target:
+                raise ValueError("Bookmark action needs a target bookmark.")
+            bm_id = next(
+                (b["name"] for b in self.bookmark_list()
+                 if target in (b["displayName"], b["name"])),
+                target,
+            )
+            props["bookmark"] = {"expr": {"Literal": {"Value": f"'{bm_id}'"}}}
+        elif action_type == "WebUrl":
+            if not target:
+                raise ValueError("WebUrl action needs a target URL.")
+            props["webUrl"] = {"expr": {"Literal": {"Value": f"'{target}'"}}}
+
+        vco = data.setdefault("visual", {}).setdefault("visualContainerObjects", {})
+        vco["visualLink"] = [{"properties": props}]
+        vj.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        return True
 
     # ── Mobile layout ──────────────────────────────────────────────────────────
     # Each visual's mobile position is a sibling mobile.json (visualContainerMobileState).

--- a/src/pbi_cli/commands/filter_cmd.py
+++ b/src/pbi_cli/commands/filter_cmd.py
@@ -45,11 +45,63 @@ def _page_json_path(pbip: str, page: str) -> Path:
     raise click.ClickException(f"page.json not found for page '{page}'.")
 
 
+def _target_json_path(pbip: str, scope: str, page: str | None, visual: str | None) -> Path:
+    """Resolve the JSON file whose ``filterConfig`` a filter applies to.
+
+    scope ``page`` → that page's page.json (default, historical behaviour);
+    ``report`` → definition/report.json (report-level filters apply everywhere);
+    ``visual`` → that visual's visual.json (needs --page and --visual).
+    The embedded filterConfig shape is identical across all three.
+    """
+    if scope == "page":
+        if not page:
+            raise click.UsageError("--page is required for page-scope filters.")
+        return _page_json_path(pbip, page)
+
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    report_dir = b._report_dir  # type: ignore[attr-defined]
+    assert report_dir is not None
+    if scope == "report":
+        rj = report_dir / "definition" / "report.json"
+        if not rj.exists():
+            raise click.ClickException("definition/report.json not found (PBIR GA only).")
+        return rj
+    # visual scope
+    if not (page and visual):
+        raise click.UsageError("--page and --visual are required for visual-scope filters.")
+    found = b._ga_find_visual_json(page, visual)  # type: ignore[attr-defined]
+    if not found:
+        raise click.ClickException(f"Visual '{visual}' not found on page '{page}'.")
+    return found[0]
+
+
+def _scope_label(scope: str, page: str | None, visual: str | None) -> str:
+    if scope == "report":
+        return "report"
+    if scope == "visual":
+        return f"visual '{visual}' on '{page}'"
+    return f"page '{page}'"
+
+
 def _append_filter(page_json: Path, filter_container: dict) -> None:
-    """Append a FilterContainer into the page's ``filterConfig.filters``."""
+    """Append a FilterContainer into the target's ``filterConfig.filters``."""
     data = json.loads(page_json.read_text(encoding="utf-8"))
     data["filterConfig"] = fb.add_filter(data.get("filterConfig"), filter_container)
     page_json.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+_SCOPE_OPTION = click.option(
+    "--scope",
+    type=click.Choice(["page", "report", "visual"]),
+    default="page",
+    show_default=True,
+    help="Where the filter applies: page (default), report (all pages), or a single visual.",
+)
+_VISUAL_OPTION = click.option(
+    "--visual", "visual", default=None, help="Visual name (required for --scope visual)."
+)
 
 
 def _read_filters(page_json: Path) -> list[dict]:
@@ -59,14 +111,19 @@ def _read_filters(page_json: Path) -> list[dict]:
 
 @filter_cmd.command("list")
 @click.option("--pbip", required=True)
-@click.option("--page", required=True)
+@click.option("--page", default=None)
+@_SCOPE_OPTION
+@_VISUAL_OPTION
 @click.pass_context
-def filter_list(ctx: click.Context, pbip: str, page: str) -> None:
-    """List all filters applied to a report page."""
-    pj = _page_json_path(pbip, page)
+def filter_list(
+    ctx: click.Context, pbip: str, page: str | None, scope: str, visual: str | None
+) -> None:
+    """List filters applied at page (default), report, or visual scope."""
+    label = _scope_label(scope, page, visual)
+    pj = _target_json_path(pbip, scope, page, visual)
     filters = _read_filters(pj)
     if not filters:
-        console.print(f"[yellow]No filters on page '{page}'.[/yellow]")
+        console.print(f"[yellow]No filters on {label}.[/yellow]")
         return
     # Project to a friendly summary rather than dumping raw FilterDefinition JSON.
     rows = [
@@ -79,21 +136,24 @@ def filter_list(ctx: click.Context, pbip: str, page: str) -> None:
         }
         for f in filters
     ]
-    output_json_or_table(rows, ctx, title=f"Filters on '{page}'")
+    output_json_or_table(rows, ctx, title=f"Filters on {label}")
 
 
 def _describe_field(field: dict) -> str:
     for kind in ("Column", "Measure"):
         node = field.get(kind)
         if node:
-            entity = node.get("Expression", {}).get("SourceRef", {}).get("Source", "")
+            src = node.get("Expression", {}).get("SourceRef", {})
+            entity = src.get("Entity") or src.get("Source") or ""
             return f"{entity}.{node.get('Property', '')}" if entity else node.get("Property", "")
     return ""
 
 
 @filter_cmd.command("add-relative-date")
 @click.option("--pbip", required=True)
-@click.option("--page", required=True, help="Page to apply filter to.")
+@click.option("--page", default=None, help="Page to apply filter to (page/visual scope).")
+@_SCOPE_OPTION
+@_VISUAL_OPTION
 @click.option("--table", required=True, help="Table containing the date column.")
 @click.option("--column", required=True, help="Date column name.")
 @click.option("--last", type=int, required=True, help="Number of time units (e.g. 30).")
@@ -115,7 +175,9 @@ def _describe_field(field: dict) -> str:
 def filter_add_relative_date(
     ctx: click.Context,
     pbip: str,
-    page: str,
+    page: str | None,
+    scope: str,
+    visual: str | None,
     table: str,
     column: str,
     last: int,
@@ -124,29 +186,34 @@ def filter_add_relative_date(
     locked: bool,
     hidden: bool,
 ) -> None:
-    """Add a relative-date filter to a page (e.g. 'last 30 days').
+    """Add a relative-date filter (e.g. 'last 30 days') at page/report/visual scope.
 
     \b
     Example:
       pbi filter add-relative-date --pbip MyReport --page "Sales" \\
         --table Calendar --column Date --last 30 --unit Days
+      pbi filter add-relative-date --pbip MyReport --scope report \\
+        --table Calendar --column Date --last 1 --unit Years
     """
-    if dry_run_echo(ctx, f"add relative-date filter: last {last} {unit} on {table}[{column}]"):
+    label = _scope_label(scope, page, visual)
+    if dry_run_echo(ctx, f"add relative-date filter: last {last} {unit} on {table}[{column}] -> {label}"):  # noqa: E501
         return
     fc = fb.build_relative_date_filter(
         table, column, last, unit, include_today=not exclude_today, locked=locked, hidden=hidden
     )
-    pj = _page_json_path(pbip, page)
+    pj = _target_json_path(pbip, scope, page, visual)
     _append_filter(pj, fc)
     console.print(
-        f"[green]Filter added:[/green] last {last} {unit} on {table}[{column}] -> page '{page}'"
+        f"[green]Filter added:[/green] last {last} {unit} on {table}[{column}] -> {label}"
     )
     console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
 
 
 @filter_cmd.command("add-value")
 @click.option("--pbip", required=True)
-@click.option("--page", required=True)
+@click.option("--page", default=None)
+@_SCOPE_OPTION
+@_VISUAL_OPTION
 @click.option("--table", required=True)
 @click.option("--column", required=True)
 @click.option("--values", required=True, help="Comma-separated list of values.")
@@ -157,7 +224,9 @@ def filter_add_relative_date(
 def filter_add_value(
     ctx: click.Context,
     pbip: str,
-    page: str,
+    page: str | None,
+    scope: str,
+    visual: str | None,
     table: str,
     column: str,
     values: str,
@@ -165,7 +234,7 @@ def filter_add_value(
     locked: bool,
     hidden: bool,
 ) -> None:
-    """Add a categorical (value-in/-out) filter to a page.
+    """Add a categorical (value-in/-out) filter at page/report/visual scope.
 
     \b
     Example:
@@ -176,22 +245,25 @@ def filter_add_value(
     if not value_list:
         raise click.UsageError("--values must contain at least one value.")
     verb = "exclude" if exclude else "include"
-    if dry_run_echo(ctx, f"add value filter: {verb} {table}[{column}] in {value_list}"):
+    label = _scope_label(scope, page, visual)
+    if dry_run_echo(ctx, f"add value filter: {verb} {table}[{column}] in {value_list} -> {label}"):
         return
     fc = fb.build_value_filter(
         table, column, value_list, exclude=exclude, locked=locked, hidden=hidden
     )
-    pj = _page_json_path(pbip, page)
+    pj = _target_json_path(pbip, scope, page, visual)
     _append_filter(pj, fc)
     console.print(
-        f"[green]Filter added:[/green] {verb} {table}[{column}] in {value_list} -> page '{page}'"
+        f"[green]Filter added:[/green] {verb} {table}[{column}] in {value_list} -> {label}"
     )
     console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
 
 
 @filter_cmd.command("add-advanced")
 @click.option("--pbip", required=True)
-@click.option("--page", required=True)
+@click.option("--page", default=None)
+@_SCOPE_OPTION
+@_VISUAL_OPTION
 @click.option("--table", required=True)
 @click.option("--column", required=True, help="Column or measure to filter.")
 @click.option("--measure", "is_measure", is_flag=True, help="Treat --column as a DAX measure.")
@@ -215,7 +287,9 @@ def filter_add_value(
 def filter_add_advanced(
     ctx: click.Context,
     pbip: str,
-    page: str,
+    page: str | None,
+    scope: str,
+    visual: str | None,
     table: str,
     column: str,
     is_measure: bool,
@@ -224,7 +298,7 @@ def filter_add_advanced(
     locked: bool,
     hidden: bool,
 ) -> None:
-    """Add an advanced numeric filter (one or two comparisons) to a page.
+    """Add an advanced numeric filter at page/report/visual scope.
 
     \b
     Example — keep rows where Profit is between 0 and 1,000,000:
@@ -241,7 +315,10 @@ def filter_add_advanced(
             parsed.append((op.strip(), float(raw)))
         except ValueError as exc:
             raise click.UsageError(f"--condition '{c}' has a non-numeric threshold.") from exc
-    if dry_run_echo(ctx, f"add advanced filter on {table}[{column}]: {parsed} ({logic})"):
+    label = _scope_label(scope, page, visual)
+    if dry_run_echo(
+        ctx, f"add advanced filter on {table}[{column}]: {parsed} ({logic}) -> {label}"
+    ):
         return
     try:
         fc = fb.build_advanced_filter(
@@ -249,26 +326,31 @@ def filter_add_advanced(
         )
     except ValueError as exc:
         raise click.UsageError(str(exc)) from exc
-    pj = _page_json_path(pbip, page)
+    pj = _target_json_path(pbip, scope, page, visual)
     _append_filter(pj, fc)
     console.print(
-        f"[green]Filter added:[/green] advanced {table}[{column}] {parsed} -> page '{page}'"
+        f"[green]Filter added:[/green] advanced {table}[{column}] {parsed} -> {label}"
     )
     console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see changes.")
 
 
 @filter_cmd.command("clear")
 @click.option("--pbip", required=True)
-@click.option("--page", required=True)
+@click.option("--page", default=None)
+@_SCOPE_OPTION
+@_VISUAL_OPTION
 @click.pass_context
-def filter_clear(ctx: click.Context, pbip: str, page: str) -> None:
-    """Remove all filters from a report page."""
-    if dry_run_echo(ctx, f"clear all filters from page '{page}'"):
+def filter_clear(
+    ctx: click.Context, pbip: str, page: str | None, scope: str, visual: str | None
+) -> None:
+    """Remove all filters at page (default), report, or visual scope."""
+    label = _scope_label(scope, page, visual)
+    if dry_run_echo(ctx, f"clear all filters from {label}"):
         return
-    pj = _page_json_path(pbip, page)
+    pj = _target_json_path(pbip, scope, page, visual)
     data = json.loads(pj.read_text(encoding="utf-8"))
     count = len(data.get("filterConfig", {}).get("filters", []))
     if "filterConfig" in data:
         data["filterConfig"]["filters"] = []
     pj.write_text(json.dumps(data, indent=2), encoding="utf-8")
-    console.print(f"[green]Cleared[/green] {count} filter(s) from page '{page}'.")
+    console.print(f"[green]Cleared[/green] {count} filter(s) from {label}.")

--- a/src/pbi_cli/commands/model.py
+++ b/src/pbi_cli/commands/model.py
@@ -478,6 +478,68 @@ def _scan_pbir_for_field(pbip: str, name: str, is_measure: bool) -> list[dict]:
     return results
 
 
+@model.command("field-parameter")
+@click.option("--pbip", required=True, help="Path to the .pbip project (must have a local model).")
+@click.option("--name", required=True, help="Field parameter / table name, e.g. 'Metric'.")
+@click.option(
+    "--item",
+    "items",
+    multiple=True,
+    required=True,
+    help="A selectable field as 'Label:Table:Field[:measure]' (repeatable, in display order).",
+)
+@click.pass_context
+def model_field_parameter(
+    ctx: click.Context, pbip: str, name: str, items: tuple[str, ...]
+) -> None:
+    """Generate a field parameter (a calculated table users can switch fields with).
+
+    Writes a TMDL table into the project's semantic model and registers it in
+    model.tmdl. Bind the new '<name>' column to a slicer (and the visual's value
+    role) so report users can swap measures/dimensions live.
+
+    \b
+    Example:
+      pbi model field-parameter --pbip MyReport --name "Metric" \\
+        --item "Sales:financials:Sales:measure" \\
+        --item "Profit:financials:Profit:measure" \\
+        --item "Units:financials:Units Sold:measure"
+    """
+    from pbi_cli.intelligence.field_parameter import FieldParamItem, add_field_parameter
+
+    parsed: list[FieldParamItem] = []
+    for raw in items:
+        parts = raw.split(":")
+        if len(parts) < 3:
+            raise click.UsageError(
+                f"--item '{raw}' must be 'Label:Table:Field[:measure]'."
+            )
+        label, table, fieldname = parts[0], parts[1], parts[2]
+        is_measure = len(parts) > 3 and parts[3].strip().lower() == "measure"
+        if not (label and table and fieldname):
+            raise click.UsageError(f"--item '{raw}' has an empty Label, Table or Field.")
+        parsed.append(FieldParamItem(label=label, table=table, field=fieldname, is_measure=is_measure))  # noqa: E501
+
+    if dry_run_echo(ctx, f"generate field parameter '{name}' with {len(parsed)} item(s)"):
+        return
+
+    try:
+        result = add_field_parameter(pbip, name, parsed)
+    except (FileNotFoundError, ValueError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+
+    console.print(
+        f"[green]Field parameter created:[/green] '{result['table']}' "
+        f"({result['items']} field(s)) → {result['path']}"
+    )
+    console.print(
+        "[yellow]Next:[/yellow] add a slicer bound to "
+        f"'{name}'[{name}] and bind '{name}'[{name} Fields] to your visual's value role."
+    )
+    console.print("[yellow]Tip:[/yellow] Reload the model in Power BI Desktop to verify.")
+
+
 def _build_measure_suggestions(tables: list, columns: list) -> list[dict]:
     suggestions = []
     numeric_cols = [c for c in columns if c.get("dataType") in ("Decimal", "Double", "Int64")]

--- a/src/pbi_cli/commands/report.py
+++ b/src/pbi_cli/commands/report.py
@@ -78,6 +78,38 @@ def report_clear_page(ctx: click.Context, pbip: str, page: str) -> None:
     console.print(f"[green]Cleared[/green] all visuals on '{page}'.")
 
 
+@report.command("page-duplicate")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--name", required=True, help="Display name of the page to duplicate.")
+@click.option("--new-name", default=None, help="Display name for the copy (default: '<name> (copy)').")  # noqa: E501
+@click.pass_context
+def report_page_duplicate(ctx: click.Context, pbip: str, name: str, new_name: str | None) -> None:
+    """Duplicate a page and all its visuals under a fresh, independent id.
+
+    Visual ids are regenerated and internal references (groups, visual
+    interactions) are remapped, so the copy never aliases the original.
+
+    \b
+    Example:
+      pbi report page-duplicate --pbip MyReport --name "Sales" --new-name "Sales (EMEA)"
+    """
+    if dry_run_echo(ctx, f"duplicate page '{name}'"):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        result = b.page_duplicate(name, new_display_name=new_name)
+    except (ValueError, RuntimeError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    console.print(
+        f"[green]Page duplicated:[/green] '{result['displayName']}' "
+        f"({result['visuals']} visual(s), id: {result['name']})"
+    )
+    console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see it.")
+
+
 # ── Scaffold ───────────────────────────────────────────────────────────────────
 
 
@@ -616,6 +648,40 @@ def report_lint(ctx: click.Context, pbip: str, fail_on: str) -> None:
         console.print("[green]No report lint findings.[/green]")
     rank = {"error": 3, "warning": 2, "info": 1, "never": 99}
     worst = max((rank.get(v["severity"], 0) for v in violations), default=0)
+    if worst >= rank[fail_on]:
+        raise SystemExit(3)
+
+
+@report.command("validate")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option(
+    "--fail-on", default="error", show_default=True,
+    type=click.Choice(["error", "warning", "info", "never"]),
+    help="Exit 3 when findings at or above this severity exist (CI gate).",
+)
+@click.pass_context
+def report_validate(ctx: click.Context, pbip: str, fail_on: str) -> None:
+    """Validate PBIR files: schema drift, structural invariants, referential integrity.
+
+    Encodes the runtime-validator rules Power BI Desktop enforces at reload
+    (e.g. no $schema inside an embedded filterConfig) plus cross-file reference
+    checks (pageOrder, bookmark items, parentGroupName, visualInteractions).
+    Runs offline — no Desktop required. Exit 3 if findings reach --fail-on.
+    """
+    from pbi_cli.pbir_validate import validate_report
+
+    try:
+        findings = validate_report(pbip)
+    except FileNotFoundError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+
+    output_json_or_table(findings, ctx, title="PBIR Validation")
+    quiet_json = bool(ctx.obj and (ctx.obj.get("output_json") or ctx.obj.get("output_yaml")))
+    if not findings and not quiet_json:
+        console.print("[green]PBIR is valid — no findings.[/green]")
+    rank = {"error": 3, "warning": 2, "info": 1, "never": 99}
+    worst = max((rank.get(f["severity"], 0) for f in findings), default=0)
     if worst >= rank[fail_on]:
         raise SystemExit(3)
 

--- a/src/pbi_cli/commands/visual.py
+++ b/src/pbi_cli/commands/visual.py
@@ -89,6 +89,35 @@ def visual_list(ctx: click.Context, pbip: str, page: str) -> None:
     output_json_or_table(visuals, ctx, title=f"Visuals on '{page}'")
 
 
+@visual.command("get")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Page display name.")
+@click.option("--name", "visual_name", required=True, help="Visual name (from pbi visual list).")
+@click.pass_context
+def visual_get(ctx: click.Context, pbip: str, page: str, visual_name: str) -> None:
+    """Introspect a visual: type, position, field bindings, formatting, filters.
+
+    The read-side counterpart to add/rebind/format — useful for auditing,
+    idempotent edits, and understanding an existing report.
+
+    \b
+    Example:
+      pbi visual get --pbip MyReport --page "Sales" --name abc123 --json
+    """
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        info = b.visual_get(page, visual_name)
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    if info is None:
+        console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
+        raise SystemExit(1)
+    output_json_or_table(info, ctx, title=f"Visual {visual_name}")
+
+
 @visual.command("add")
 @click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
 @click.option("--page", required=True, help="Page display name to add the visual to.")
@@ -149,16 +178,20 @@ def visual_add(
         build_bar_chart,
         build_card,
         build_column_chart,
+        build_decomposition_tree,
         build_donut_chart,
         build_funnel,
         build_gauge,
+        build_key_influencers,
         build_line_chart,
         build_matrix,
         build_multi_row_card,
         build_pie_chart,
+        build_qna,
         build_ribbon_chart,
         build_scatter_chart,
         build_slicer,
+        build_smart_narrative,
         build_table,
         build_treemap,
         build_waterfall,
@@ -265,6 +298,24 @@ def visual_add(
         cat_field = FieldDef(entity=table, property=category, agg=None)
         series_field = FieldDef(entity=table, property=series, agg=None) if series else None
         body = build_ribbon_chart(cat_field, value_field, series=series_field)
+    elif vtype in ("decomptree", "keyinfluencers"):
+        if not category:
+            raise click.UsageError(
+                f"--category is required for {vtype} (the Explain-by dimension); "
+                "use --extra-columns to add more."
+            )
+        explain = [FieldDef(entity=table, property=category, agg=None)]
+        if extra_columns:
+            for col_name in extra_columns.split(","):
+                col_name = col_name.strip()
+                if col_name:
+                    explain.append(FieldDef(entity=table, property=col_name, agg=None))
+        builder = build_decomposition_tree if vtype == "decomptree" else build_key_influencers
+        body = builder(value_field, explain)
+    elif vtype == "smartnarrative":
+        body = build_smart_narrative()
+    elif vtype == "qanda":
+        body = build_qna()
     else:
         raise click.UsageError(f"Unsupported visual type: {vtype}")
 
@@ -892,6 +943,197 @@ def visual_add_element(
     console.print(
         f"[green]Added[/green] {element_type} '{result['name']}' to page '{page}'."
     )
+    console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see it.")
+
+
+@visual.command("reference-line")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Page display name.")
+@click.option("--name", "visual_name", required=True, help="Cartesian chart visual name.")
+@click.option("--value", type=float, required=True, help="Constant Y value for the line.")
+@click.option("--label", default="Target", show_default=True, help="Line label.")
+@click.option("--color", default="#E81123", show_default=True, help="Line colour (hex).")
+@click.option(
+    "--style",
+    type=click.Choice(["solid", "dashed", "dotted"]),
+    default="dashed",
+    show_default=True,
+)
+@click.option("--no-label", is_flag=True, help="Hide the line's data label.")
+@click.pass_context
+def visual_reference_line(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    visual_name: str,
+    value: float,
+    label: str,
+    color: str,
+    style: str,
+    no_label: bool,
+) -> None:
+    """Add a constant Y reference (target) line to a cartesian chart.
+
+    \b
+    Example — a 1,000,000 sales target line:
+      pbi visual reference-line --pbip R --page "Sales" --name bar1 \\
+        --value 1000000 --label "Target" --color "#E81123"
+    """
+    if dry_run_echo(ctx, f"add reference line at {value} on visual '{visual_name}'"):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        ok = b.visual_add_reference_line(
+            page, visual_name, value, name=label, color=color, style=style,
+            show_label=not no_label,
+        )
+    except (ValueError, RuntimeError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    if ok:
+        console.print(f"[green]Reference line added:[/green] {label} @ {value} on '{visual_name}'.")
+        console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see it.")
+    else:
+        console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
+        raise SystemExit(1)
+
+
+@visual.command("action")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Page display name.")
+@click.option("--name", "visual_name", required=True, help="Button/shape visual name.")
+@click.option(
+    "--type",
+    "action_type",
+    type=click.Choice(["Back", "PageNavigation", "Bookmark", "Drill", "QnA", "WebUrl"]),
+    required=True,
+    help="Action type.",
+)
+@click.option(
+    "--target",
+    default=None,
+    help="Target: page (PageNavigation), bookmark (Bookmark), or URL (WebUrl).",
+)
+@click.pass_context
+def visual_action(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    visual_name: str,
+    action_type: str,
+    target: str | None,
+) -> None:
+    """Wire a navigation/action onto a button so it actually does something.
+
+    A button added with `add-element` has no action until you set one here.
+
+    \b
+    Examples:
+      pbi visual action --pbip R --page "Home" --name btn1 --type PageNavigation --target "Detail"
+      pbi visual action --pbip R --page "Home" --name btn2 --type Bookmark --target "Q4 View"
+      pbi visual action --pbip R --page "Home" --name back1 --type Back
+    """
+    if dry_run_echo(ctx, f"set {action_type} action on visual '{visual_name}'"):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        ok = b.visual_set_action(page, visual_name, action_type, target=target)
+    except (ValueError, RuntimeError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    if ok:
+        tgt = f" → {target}" if target else ""
+        console.print(f"[green]Action set:[/green] {action_type}{tgt} on '{visual_name}'.")
+        console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see it.")
+    else:
+        console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
+        raise SystemExit(1)
+
+
+# ── Clone & move ────────────────────────────────────────────────────────────────
+
+
+@visual.command("clone")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Source page display name.")
+@click.option("--name", "visual_name", required=True, help="Visual name to clone.")
+@click.option("--to-page", default=None, help="Target page (default: same page, offset).")
+@click.option("--dx", type=int, default=24, show_default=True, help="X offset when cloning in place.")  # noqa: E501
+@click.option("--dy", type=int, default=24, show_default=True, help="Y offset when cloning in place.")  # noqa: E501
+@click.pass_context
+def visual_clone(
+    ctx: click.Context,
+    pbip: str,
+    page: str,
+    visual_name: str,
+    to_page: str | None,
+    dx: int,
+    dy: int,
+) -> None:
+    """Clone a visual under a fresh id — on the same page (offset) or another page.
+
+    Preserves bindings, formatting and conditional formatting. The clone never
+    inherits group membership.
+
+    \b
+    Example:
+      pbi visual clone --pbip R --page "Sales" --name abc123 --to-page "EMEA"
+    """
+    if dry_run_echo(ctx, f"clone visual '{visual_name}' from '{page}'"):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        result = b.visual_clone(page, visual_name, target_page=to_page, dx=dx, dy=dy)
+    except (ValueError, RuntimeError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    if not result:
+        console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
+        raise SystemExit(1)
+    console.print(
+        f"[green]Cloned[/green] '{visual_name}' → '{result['name']}' on page '{result['page']}'."
+    )
+    console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see it.")
+
+
+@visual.command("move")
+@click.option("--pbip", required=True, help="Path to the .pbip project folder or file.")
+@click.option("--page", required=True, help="Source page display name.")
+@click.option("--name", "visual_name", required=True, help="Visual name to move.")
+@click.option("--to-page", required=True, help="Target page display name.")
+@click.pass_context
+def visual_move(
+    ctx: click.Context, pbip: str, page: str, visual_name: str, to_page: str
+) -> None:
+    """Move a visual to another page, keeping its id.
+
+    Drops group membership and removes now-dangling visual interactions on the
+    source page.
+
+    \b
+    Example:
+      pbi visual move --pbip R --page "Sales" --name abc123 --to-page "Detail"
+    """
+    if dry_run_echo(ctx, f"move visual '{visual_name}' from '{page}' to '{to_page}'"):
+        return
+    from pbi_cli.backends.pbir_backend import PbirBackend
+
+    b = PbirBackend(pbip)
+    try:
+        result = b.visual_move(page, visual_name, to_page)
+    except (ValueError, RuntimeError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise SystemExit(1) from exc
+    if not result:
+        console.print(f"[red]Visual '{visual_name}' not found on page '{page}'.[/red]")
+        raise SystemExit(1)
+    console.print(f"[green]Moved[/green] '{visual_name}' to page '{to_page}'.")
     console.print("[yellow]Tip:[/yellow] Reload the report in Power BI Desktop to see it.")
 
 

--- a/src/pbi_cli/intelligence/field_parameter.py
+++ b/src/pbi_cli/intelligence/field_parameter.py
@@ -1,0 +1,145 @@
+"""Generate Power BI *field parameters* — a model-side calculated table that lets
+report users swap which measure or dimension a visual shows.
+
+A field parameter is a calculated table with three columns:
+
+  * ``<Name>``        — the display label the slicer shows (sorted by Order)
+  * ``<Name> Fields`` — the actual field reference (hidden), grouped under the label
+  * ``<Name> Order``  — sort order (hidden)
+
+and a calculated partition whose DAX is a table constructor of
+``("Label", NAMEOF('Table'[Field]), order)`` rows. The label/Fields columns carry
+the ``ParameterMetadata`` extended property that marks the table as a parameter so
+Power BI Desktop renders the "Fields" authoring UI. ``NAMEOF`` is valid for both
+columns and measures, so a single builder covers both.
+
+This writes TMDL into the project's ``*.SemanticModel`` folder and registers the
+table in ``model.tmdl`` (TMDL does not auto-discover table files — see
+:mod:`pbi_cli.tmdl_util`). The generated shape mirrors Desktop's output; reload
+the model in Desktop to confirm before publishing.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from pbi_cli.tmdl_util import ensure_ref_table, quote_tmdl_name
+
+
+@dataclass
+class FieldParamItem:
+    """One choice in a field parameter: a label and the field it maps to."""
+
+    label: str
+    table: str
+    field: str
+    is_measure: bool = False  # informational only; NAMEOF syntax is identical
+
+
+def _lineage() -> str:
+    return str(uuid.uuid4())
+
+
+def _nameof(item: FieldParamItem) -> str:
+    return f"NAMEOF('{item.table}'[{item.field}])"
+
+
+def build_field_parameter_tmdl(param_name: str, items: list[FieldParamItem]) -> str:
+    """Return the TMDL text for a field-parameter calculated table.
+
+    ``param_name`` is the table/label name (e.g. "Metric"); ``items`` are the
+    selectable fields in display order. Raises ValueError on empty input.
+    """
+    if not items:
+        raise ValueError("a field parameter needs at least one item")
+    if not re.fullmatch(r"[^\[\]]+", param_name):
+        raise ValueError("param_name must not contain square brackets")
+
+    q = quote_tmdl_name(param_name)
+    fields_col = quote_tmdl_name(f"{param_name} Fields")
+    order_col = quote_tmdl_name(f"{param_name} Order")
+    meta = 'extendedProperty ParameterMetadata = {"version":3,"kind":2}'
+
+    rows = ",\n".join(
+        f'\t\t\t\t("{it.label}", {_nameof(it)}, {i})' for i, it in enumerate(items)
+    )
+
+    return (
+        f"table {q}\n"
+        f"\tlineageTag: {_lineage()}\n"
+        # ── label column (visible, sorted by Order, grouped by Fields) ──
+        f"\n\tcolumn {q}\n"
+        f"\t\tdataType: string\n"
+        f"\t\tlineageTag: {_lineage()}\n"
+        f"\t\tsummarizeBy: none\n"
+        f"\t\tsourceColumn: [Value1]\n"
+        f"\t\tsortByColumn: {order_col}\n"
+        f"\n\t\trelatedColumnDetails\n"
+        f"\t\t\tgroupByColumn: {fields_col}\n"
+        f"\n\t\t{meta}\n"
+        # ── Fields column (hidden, the actual field reference) ──
+        f"\n\tcolumn {fields_col}\n"
+        f"\t\tdataType: string\n"
+        f"\t\tisHidden\n"
+        f"\t\tlineageTag: {_lineage()}\n"
+        f"\t\tsummarizeBy: none\n"
+        f"\t\tsourceColumn: [Value2]\n"
+        f"\n\t\t{meta}\n"
+        # ── Order column (hidden, sort key) ──
+        f"\n\tcolumn {order_col}\n"
+        f"\t\tdataType: int64\n"
+        f"\t\tformatString: 0\n"
+        f"\t\tisHidden\n"
+        f"\t\tlineageTag: {_lineage()}\n"
+        f"\t\tsummarizeBy: sum\n"
+        f"\t\tsourceColumn: [Value3]\n"
+        # ── calculated partition: the table constructor ──
+        f"\n\tpartition {q} = calculated\n"
+        f"\t\tmode: import\n"
+        f"\t\tsource =\n"
+        f"\t\t\t\t{{\n"
+        f"{rows}\n"
+        f"\t\t\t\t}}\n"
+    )
+
+
+def _semantic_model_dir(pbip_path: str | Path) -> Path:
+    """Locate the *.SemanticModel folder for a .pbip project."""
+    p = Path(pbip_path)
+    root = p.parent if p.is_file() and p.suffix == ".pbip" else p
+    candidates = sorted(root.glob("*.SemanticModel"))
+    if not candidates:
+        # The .pbip may sit beside the model; try one level up too.
+        candidates = sorted(root.parent.glob("*.SemanticModel"))
+    if not candidates:
+        raise FileNotFoundError(
+            f"No *.SemanticModel folder found near {root}. Field parameters need a "
+            "local model (a live-connection report stores no model on disk)."
+        )
+    return candidates[0]
+
+
+def add_field_parameter(
+    pbip_path: str | Path, param_name: str, items: list[FieldParamItem]
+) -> dict[str, object]:
+    """Write a field-parameter table into the project's semantic model.
+
+    Creates ``definition/tables/<name>.tmdl`` and registers it in ``model.tmdl``.
+    Returns {table, path, items}. Raises FileNotFoundError if no local model,
+    ValueError on bad input.
+    """
+    sm = _semantic_model_dir(pbip_path)
+    tables_dir = sm / "definition" / "tables"
+    tables_dir.mkdir(parents=True, exist_ok=True)
+    model_tmdl = sm / "definition" / "model.tmdl"
+    if not model_tmdl.exists():
+        raise FileNotFoundError(f"model.tmdl not found in {sm / 'definition'}.")
+
+    tmdl = build_field_parameter_tmdl(param_name, items)
+    out = tables_dir / f"{param_name}.tmdl"
+    out.write_text(tmdl, encoding="utf-8")
+    ensure_ref_table(model_tmdl, param_name)
+    return {"table": param_name, "path": str(out), "items": len(items)}

--- a/src/pbi_cli/intelligence/filter_builder.py
+++ b/src/pbi_cli/intelligence/filter_builder.py
@@ -60,6 +60,19 @@ def _measure(alias: str, measure: str) -> dict[str, Any]:
     return {"Measure": {"Expression": _source_ref(alias), "Property": measure}}
 
 
+def _field_ref(table: str, prop: str, is_measure: bool = False) -> dict[str, Any]:
+    """The FilterContainer ``field`` identifier.
+
+    Unlike the ``Where``/``From`` body (which references a query *alias* via
+    ``SourceRef.Source``), the container ``field`` must reference the *table*
+    via ``SourceRef.Entity``. Power BI Desktop cannot resolve an alias here at
+    report/visual scope and rewrites it to an empty SourceRef on its next save —
+    which then blocks the report from opening (verified live 2026-06-22).
+    """
+    key = "Measure" if is_measure else "Column"
+    return {key: {"Expression": {"SourceRef": {"Entity": table}}, "Property": prop}}
+
+
 def _string_literal(value: str) -> dict[str, Any]:
     # String literals are single-quoted inside the Value per the literal grammar.
     return {"Literal": {"Value": f"'{value}'"}}
@@ -135,7 +148,7 @@ def build_value_filter(
     }
     return _container(
         name=_filter_name(),
-        field=col,
+        field=_field_ref(table, column),
         filter_type="Exclude" if exclude else "Categorical",
         definition=definition,
         locked=locked,
@@ -193,7 +206,7 @@ def build_advanced_filter(
     }
     return _container(
         name=_filter_name(),
-        field=left,
+        field=_field_ref(table, column, is_measure=is_measure),
         filter_type="Advanced",
         definition=definition,
         locked=locked,
@@ -264,7 +277,7 @@ def build_relative_date_filter(
     }
     return _container(
         name=_filter_name(),
-        field=col,
+        field=_field_ref(table, column),
         filter_type="RelativeDate",
         definition=definition,
         locked=locked,

--- a/src/pbi_cli/intelligence/visual_builder.py
+++ b/src/pbi_cli/intelligence/visual_builder.py
@@ -268,6 +268,41 @@ def build_ribbon_chart(
     }
 
 
+# ── AI / smart visuals ──────────────────────────────────────────────────────────
+# Decomposition tree and key influencers both take an "Analyze" measure/field plus
+# one or more "Explain" dimensions. Smart narrative and Q&A carry no query bindings.
+
+
+def build_decomposition_tree(analyze: FieldDef, explain_by: list[FieldDef]) -> dict[str, Any]:
+    """Decomposition tree: an Analyze value broken down by Explain dimensions."""
+    return {
+        "visualType": "decompositionTreeVisual",
+        "query": {"queryState": _query_state({"Analyze": [analyze], "Explain": explain_by})},
+        "objects": {},
+        "visualContainerObjects": {},
+    }
+
+
+def build_key_influencers(analyze: FieldDef, explain_by: list[FieldDef]) -> dict[str, Any]:
+    """Key influencers: what drives the Analyze field, explained by Explain fields."""
+    return {
+        "visualType": "keyDrivers",
+        "query": {"queryState": _query_state({"Analyze": [analyze], "Explain": explain_by})},
+        "objects": {},
+        "visualContainerObjects": {},
+    }
+
+
+def build_smart_narrative() -> dict[str, Any]:
+    """Smart narrative (auto-generated text summary). No query bindings required."""
+    return {"visualType": "narrativeVisual", "objects": {}, "visualContainerObjects": {}}
+
+
+def build_qna() -> dict[str, Any]:
+    """Q&A visual (natural-language query box). No query bindings required."""
+    return {"visualType": "qnaVisual", "objects": {}, "visualContainerObjects": {}}
+
+
 # ── Non-data elements: textbox, buttons, navigators ─────────────────────────────
 # These have no query bindings. Shapes verified against Power BI Desktop output:
 # a blank button serialises as visualType "actionButton" with objects.icon.shapeType;

--- a/src/pbi_cli/pbir_validate.py
+++ b/src/pbi_cli/pbir_validate.py
@@ -1,0 +1,322 @@
+"""PBIR structural + referential validation.
+
+The schema registry in :mod:`pbi_cli.backends.pbir_schemas` records the *current*
+published schema versions, but nothing checked that the files we (and Desktop)
+write actually conform. Pulling the live JSON Schemas would add a network
+dependency and the ``jsonschema`` package; more importantly, the rules that
+actually break a report at *reload* time are runtime-validator rules that the
+published JSON Schemas don't even express (e.g. "no ``$schema`` inside an embedded
+``filterConfig``" — verified live, see :mod:`pbi_cli.intelligence.filter_builder`).
+
+So this module validates the invariants we've reverse-engineered and verified
+against Power BI Desktop, plus referential integrity across the file set. It runs
+fully offline on any OS with no Desktop, mirroring :mod:`pbi_cli.pbir_analysis`.
+
+Each finding is ``{rule, severity, object, message}`` (same shape as
+``pbir_analysis.lint_report``). Severity is ``error`` | ``warning`` | ``info``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from pbi_cli.backends import pbir_schemas as _schemas
+
+_NAME_RE = re.compile(r"^[\w-]+$")
+
+# Map a published $schema URL back to (name, version) so we can flag drift.
+_SCHEMA_URL_RE = re.compile(
+    r"/fabric/item/report/definition/(?P<name>[A-Za-z0-9]+)/(?P<version>[\d.]+)/schema\.json$"
+)
+
+
+def _finding(rule: str, severity: str, obj: str, message: str) -> dict[str, str]:
+    return {"rule": rule, "severity": severity, "object": obj, "message": message}
+
+
+def _report_dir(path: str | Path) -> Path:
+    p = Path(path)
+    if p.is_file() and p.suffix == ".pbip":
+        p = p.parent
+    if p.name.endswith(".Report"):
+        return p
+    dirs = sorted(p.glob("*.Report"))
+    if not dirs:
+        raise FileNotFoundError(f"No *.Report folder found in {p}.")
+    return dirs[0]
+
+
+def _load_json(path: Path, findings: list[dict[str, str]], obj: str) -> dict[str, Any] | None:
+    """Parse a JSON file, recording a blocking finding on malformed JSON."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        findings.append(_finding("pbir.invalid-json", "error", obj, f"Cannot parse: {exc}"))
+        return None
+
+
+def _check_schema_url(
+    data: dict[str, Any], expected: str, findings: list[dict[str, str]], obj: str
+) -> None:
+    """Flag a missing/unknown/drifted ``$schema`` against the registry value."""
+    url = data.get("$schema")
+    if not url:
+        findings.append(
+            _finding("pbir.missing-schema", "warning", obj, "No $schema URL — editors lose validation hints.")  # noqa: E501
+        )
+        return
+    m = _SCHEMA_URL_RE.search(url)
+    em = _SCHEMA_URL_RE.search(expected)
+    if not m:
+        findings.append(
+            _finding("pbir.unknown-schema", "warning", obj, f"Unrecognised $schema: {url}")
+        )
+        return
+    if em and m.group("name") == em.group("name") and m.group("version") != em.group("version"):
+        findings.append(
+            _finding(
+                "pbir.schema-version-drift", "info", obj,
+                f"{m.group('name')} schema is v{m.group('version')}; "
+                f"registry expects v{em.group('version')}.",
+            )
+        )
+
+
+def _check_filter_config(
+    container: dict[str, Any], findings: list[dict[str, str]], obj: str
+) -> None:
+    """Validate an embedded filterConfig against the rules Desktop enforces at reload.
+
+    1. It must not carry a ``$schema`` key (Desktop rejects it).
+    2. Each filter's ``field`` Column/Measure must reference a table — its
+       ``Expression.SourceRef`` needs an ``Entity`` or ``Source``. An empty
+       SourceRef ("invalid value", verified live) blocks the report from opening.
+    """
+    fc = container.get("filterConfig")
+    if not isinstance(fc, dict):
+        return
+    if "$schema" in fc:
+        findings.append(
+            _finding(
+                "pbir.filterconfig-schema", "error", obj,
+                "Embedded filterConfig carries a $schema key — Power BI Desktop "
+                "rejects this at reload ('additional property $schema').",
+            )
+        )
+    for i, flt in enumerate(fc.get("filters", [])):
+        field = flt.get("field", {})
+        node = field.get("Column") or field.get("Measure")
+        if not isinstance(node, dict):
+            continue
+        srcref = node.get("Expression", {}).get("SourceRef", {})
+        if not (srcref.get("Entity") or srcref.get("Source")):
+            findings.append(
+                _finding(
+                    "pbir.filter-field-sourceref", "error", obj,
+                    f"filterConfig.filters[{i}].field SourceRef has neither Entity nor "
+                    "Source — Power BI Desktop reports an invalid value and will not open "
+                    "the report.",
+                )
+            )
+        elif srcref.get("Source") and not srcref.get("Entity"):
+            findings.append(
+                _finding(
+                    "pbir.filter-field-alias", "warning", obj,
+                    f"filterConfig.filters[{i}].field SourceRef uses a query alias "
+                    f"('Source': {srcref['Source']!r}) instead of a table ('Entity'). "
+                    "Desktop cannot resolve an alias here and rewrites it to an empty, "
+                    "report-blocking SourceRef on its next save — use Entity.",
+                )
+            )
+
+
+def validate_report(path: str | Path) -> list[dict[str, str]]:
+    """Validate a PBIR GA report folder. Returns a list of findings (possibly empty)."""
+    report_dir = _report_dir(path)
+    findings: list[dict[str, str]] = []
+
+    definition = report_dir / "definition"
+    if not definition.is_dir():
+        findings.append(
+            _finding(
+                "pbir.not-ga", "error", str(report_dir),
+                "No definition/ folder — only PBIR GA reports can be validated. "
+                "Re-save as a Power BI project (.pbip) in a current Desktop.",
+            )
+        )
+        return findings
+
+    # ── report.json ────────────────────────────────────────────────────────────
+    report_json = definition / "report.json"
+    if not report_json.exists():
+        findings.append(_finding("pbir.missing-report-json", "error", "report.json",
+                                 "definition/report.json is missing."))
+    else:
+        data = _load_json(report_json, findings, "report.json")
+        if data is not None:
+            _check_schema_url(data, _schemas.definition_schema("report"), findings, "report.json")
+            _check_filter_config(data, findings, "report.json (report-level filters)")
+
+    # ── pages ───────────────────────────────────────────────────────────────────
+    pages_dir = definition / "pages"
+    page_ids: dict[str, str] = {}  # id -> displayName
+    display_counts: dict[str, int] = {}
+    page_visuals: dict[str, set[str]] = {}
+
+    if pages_dir.is_dir():
+        order_meta = _load_json(pages_dir / "pages.json", findings, "pages.json") \
+            if (pages_dir / "pages.json").exists() else {}
+        order_meta = order_meta or {}
+
+        for page_dir in sorted(d for d in pages_dir.iterdir() if d.is_dir()):
+            pj = page_dir / "page.json"
+            obj = f"Page folder '{page_dir.name}'"
+            if not pj.exists():
+                findings.append(_finding("pbir.page-missing-json", "error", obj,
+                                         "Folder has no page.json."))
+                continue
+            data = _load_json(pj, findings, obj)
+            if data is None:
+                continue
+            pid = data.get("name", "")
+            disp = data.get("displayName", page_dir.name)
+            obj = f"Page '{disp}'"
+            _check_schema_url(data, _schemas.definition_schema("page"), findings, obj)
+            _check_filter_config(data, findings, f"{obj} (page filters)")
+            if not pid:
+                findings.append(
+                    _finding("pbir.page-no-name", "error", obj, "page.json has no name.")
+                )
+            elif not _NAME_RE.match(pid):
+                findings.append(_finding(
+                    "pbir.bad-name", "error", obj,
+                    f"Page name '{pid}' is not a valid PBIR id (word chars/hyphens).",
+                ))
+            if pid and pid != page_dir.name:
+                findings.append(_finding("pbir.page-name-mismatch", "warning", obj,
+                                         f"page.json name '{pid}' != folder '{page_dir.name}'."))
+            page_ids[pid] = disp
+            display_counts[disp] = display_counts.get(disp, 0) + 1
+
+            # Drillthrough pages need a drillthrough field.
+            if data.get("pageType") == "Drillthrough" and not data.get("drillthroughFields"):
+                findings.append(_finding("pbir.drillthrough-no-field", "warning", obj,
+                                         "Drillthrough page has no drillthroughFields — drill target is undefined."))  # noqa: E501
+
+            # Visuals on this page.
+            vids: set[str] = set()
+            group_ids: set[str] = set()
+            vd = page_dir / "visuals"
+            if vd.is_dir():
+                for vdir in sorted(d for d in vd.iterdir() if d.is_dir()):
+                    vj = vdir / "visual.json"
+                    vobj = f"Visual '{vdir.name}' on '{disp}'"
+                    if not vj.exists():
+                        findings.append(_finding("pbir.visual-missing-json", "error", vobj,
+                                                 "Folder has no visual.json."))
+                        continue
+                    vdata = _load_json(vj, findings, vobj)
+                    if vdata is None:
+                        continue
+                    _check_schema_url(vdata, _schemas.definition_schema("visualContainer"),
+                                      findings, vobj)
+                    _check_filter_config(vdata, findings, f"{vobj} (visual filters)")
+                    vname = vdata.get("name", "")
+                    if not vname:
+                        findings.append(_finding("pbir.visual-no-name", "error", vobj,
+                                                 "visual.json has no name."))
+                    elif vname in vids:
+                        findings.append(_finding("pbir.duplicate-visual", "error", vobj,
+                                                 f"Duplicate visual name '{vname}' on the page."))
+                    vids.add(vname or vdir.name)
+                    if "position" not in vdata:
+                        findings.append(_finding("pbir.visual-no-position", "warning", vobj,
+                                                 "visual.json has no position block."))
+                    is_group = "visualGroup" in vdata
+                    if is_group:
+                        group_ids.add(vname or vdir.name)
+                    elif "visual" not in vdata:
+                        findings.append(_finding("pbir.visual-no-body", "error", vobj,
+                                                 "visual.json has neither a 'visual' nor 'visualGroup' block."))  # noqa: E501
+                # Second pass: parentGroupName must resolve to a group on the page.
+                for vdir in sorted(d for d in vd.iterdir() if d.is_dir()):
+                    vj = vdir / "visual.json"
+                    if not vj.exists():
+                        continue
+                    vdata = _load_json(vj, [], "")  # already reported above
+                    if not vdata:
+                        continue
+                    parent = vdata.get("parentGroupName")
+                    if parent and parent not in group_ids:
+                        findings.append(_finding(
+                            "pbir.dangling-group-ref", "error",
+                            f"Visual '{vdir.name}' on '{disp}'",
+                            f"parentGroupName '{parent}' has no matching group on the page.",
+                        ))
+            page_visuals[disp] = vids
+
+            # visualInteractions must reference visuals that exist on the page.
+            for inter in data.get("visualInteractions", []):
+                for slot in ("source", "target"):
+                    ref = inter.get(slot)
+                    if ref and ref not in vids:
+                        findings.append(_finding(
+                            "pbir.dangling-interaction", "warning", obj,
+                            f"visualInteraction {slot} '{ref}' is not a visual on this page.",
+                        ))
+
+        # pages.json order references.
+        for pid in order_meta.get("pageOrder", []):
+            if pid not in page_ids:
+                findings.append(_finding("pbir.dangling-page-order", "warning", "pages.json",
+                                         f"pageOrder references unknown page id '{pid}'."))
+        active = order_meta.get("activePageName")
+        if active and active not in page_ids:
+            findings.append(_finding("pbir.dangling-active-page", "warning", "pages.json",
+                                     f"activePageName '{active}' is not a known page."))
+        for disp, n in display_counts.items():
+            if n > 1:
+                findings.append(_finding("pbir.duplicate-page-name", "warning", f"Page '{disp}'",
+                                         f"{n} pages share the display name '{disp}'."))
+
+    # ── bookmarks ────────────────────────────────────────────────────────────────
+    bdir = definition / "bookmarks"
+    if bdir.is_dir():
+        file_ids: set[str] = set()
+        for entry in sorted(bdir.iterdir()):
+            if not entry.is_file() or not entry.name.endswith(".bookmark.json"):
+                continue
+            obj = f"Bookmark file '{entry.name}'"
+            data = _load_json(entry, findings, obj)
+            if data is None:
+                continue
+            _check_schema_url(data, _schemas.definition_schema("bookmark"), findings, obj)
+            bid = data.get("name", "")
+            disp = data.get("displayName", bid)
+            obj = f"Bookmark '{disp}'"
+            file_ids.add(bid)
+            if not data.get("explorationState"):
+                findings.append(_finding("pbir.bookmark-no-state", "warning", obj,
+                                         "No explorationState — Desktop may strip this bookmark."))
+            active_section = data.get("explorationState", {}).get("activeSection")
+            if active_section and active_section not in page_ids:
+                findings.append(_finding("pbir.bookmark-dangling-page", "warning", obj,
+                                         f"explorationState.activeSection '{active_section}' is not a known page."))  # noqa: E501
+
+        meta = _load_json(bdir / "bookmarks.json", findings, "bookmarks.json") \
+            if (bdir / "bookmarks.json").exists() else {}
+        for item in (meta or {}).get("items", []):
+            iid = item.get("name")
+            if iid and iid not in file_ids and "children" not in item:
+                findings.append(_finding("pbir.dangling-bookmark", "warning", "bookmarks.json",
+                                         f"items references unknown bookmark id '{iid}'."))
+            for child in item.get("children", []):
+                cid = child.get("name")
+                if cid and cid not in file_ids:
+                    findings.append(_finding("pbir.dangling-bookmark-child", "warning", "bookmarks.json",  # noqa: E501
+                                             f"group '{item.get('displayName', iid)}' references unknown bookmark '{cid}'."))  # noqa: E501
+
+    return findings

--- a/tests/unit/test_commands_filter.py
+++ b/tests/unit/test_commands_filter.py
@@ -210,6 +210,62 @@ class TestFilterAddValue:
         assert "DRY RUN" in result.output
 
 
+class TestFilterScope:
+    def _report_json_path(self, tmp_path: Path) -> Path:
+        return Path(tmp_path) / "TestReport.Report" / "definition" / "report.json"
+
+    def test_report_scope_writes_report_json(self, runner, tmp_path):
+        pbip = _make_fake_pbip(tmp_path)
+        # report-level filters need definition/report.json to exist.
+        rj = self._report_json_path(tmp_path)
+        rj.write_text(json.dumps({"$schema": schemas.definition_schema("report")}), encoding="utf-8")
+        result = _run(runner, "filter", "add-value",
+                      "--pbip", pbip, "--scope", "report",
+                      "--table", "Sales", "--column", "Region", "--values", "UK")
+        assert result.exit_code == 0, result.output
+        data = json.loads(rj.read_text(encoding="utf-8"))
+        filters = data.get("filterConfig", {}).get("filters", [])
+        assert len(filters) == 1
+        # Embedded filterConfig must NOT carry a $schema (Desktop rejects it).
+        assert "$schema" not in data["filterConfig"]
+        assert "report" in result.output
+
+    def test_report_scope_missing_report_json_errors(self, runner, tmp_path):
+        pbip = _make_fake_pbip(tmp_path)
+        result = _run(runner, "filter", "add-value",
+                      "--pbip", pbip, "--scope", "report",
+                      "--table", "Sales", "--column", "Region", "--values", "UK")
+        assert result.exit_code != 0
+
+    def test_visual_scope_writes_visual_json(self, runner, tmp_path):
+        from pbi_cli.backends.pbir_backend import PbirBackend
+        from pbi_cli.intelligence.visual_builder import (
+            AGG_SUM, FieldDef, VisualSpec, build_card,
+        )
+
+        pbip = _make_fake_pbip(tmp_path)
+        b = PbirBackend(pbip)
+        spec = VisualSpec("card", build_card(FieldDef(entity="Sales", property="Amount", agg=AGG_SUM)))
+        name = b.visual_add("Page1", spec)["name"]
+
+        result = _run(runner, "filter", "add-value",
+                      "--pbip", pbip, "--scope", "visual", "--page", "Page1",
+                      "--visual", name,
+                      "--table", "Sales", "--column", "Region", "--values", "UK")
+        assert result.exit_code == 0, result.output
+        _, data = b._ga_find_visual_json("Page1", name)
+        filters = data.get("filterConfig", {}).get("filters", [])
+        assert len(filters) == 1
+        assert "$schema" not in data["filterConfig"]
+
+    def test_visual_scope_requires_visual(self, runner, tmp_path):
+        pbip = _make_fake_pbip(tmp_path)
+        result = _run(runner, "filter", "add-value",
+                      "--pbip", pbip, "--scope", "visual", "--page", "Page1",
+                      "--table", "Sales", "--column", "Region", "--values", "UK")
+        assert result.exit_code != 0
+
+
 class TestFilterClear:
     def test_clear_empty_page(self, runner, tmp_path):
         pbip = _make_fake_pbip(tmp_path)

--- a/tests/unit/test_commands_filter.py
+++ b/tests/unit/test_commands_filter.py
@@ -218,7 +218,9 @@ class TestFilterScope:
         pbip = _make_fake_pbip(tmp_path)
         # report-level filters need definition/report.json to exist.
         rj = self._report_json_path(tmp_path)
-        rj.write_text(json.dumps({"$schema": schemas.definition_schema("report")}), encoding="utf-8")
+        rj.write_text(
+            json.dumps({"$schema": schemas.definition_schema("report")}), encoding="utf-8"
+        )
         result = _run(runner, "filter", "add-value",
                       "--pbip", pbip, "--scope", "report",
                       "--table", "Sales", "--column", "Region", "--values", "UK")
@@ -240,12 +242,16 @@ class TestFilterScope:
     def test_visual_scope_writes_visual_json(self, runner, tmp_path):
         from pbi_cli.backends.pbir_backend import PbirBackend
         from pbi_cli.intelligence.visual_builder import (
-            AGG_SUM, FieldDef, VisualSpec, build_card,
+            AGG_SUM,
+            FieldDef,
+            VisualSpec,
+            build_card,
         )
 
         pbip = _make_fake_pbip(tmp_path)
         b = PbirBackend(pbip)
-        spec = VisualSpec("card", build_card(FieldDef(entity="Sales", property="Amount", agg=AGG_SUM)))
+        field = FieldDef(entity="Sales", property="Amount", agg=AGG_SUM)
+        spec = VisualSpec("card", build_card(field))
         name = b.visual_add("Page1", spec)["name"]
 
         result = _run(runner, "filter", "add-value",

--- a/tests/unit/test_field_parameter.py
+++ b/tests/unit/test_field_parameter.py
@@ -1,0 +1,66 @@
+"""Unit tests for field-parameter generation (pbi model field-parameter)."""
+
+from __future__ import annotations
+
+import pytest
+
+from pbi_cli.intelligence.field_parameter import (
+    FieldParamItem,
+    add_field_parameter,
+    build_field_parameter_tmdl,
+)
+from pbi_cli.project_scaffold import create_project
+
+
+def _items() -> list[FieldParamItem]:
+    return [
+        FieldParamItem("Sales", "financials", "Sales", is_measure=True),
+        FieldParamItem("Profit", "financials", "Profit", is_measure=True),
+        FieldParamItem("Units", "financials", "Units Sold", is_measure=True),
+    ]
+
+
+class TestBuildTmdl:
+    def test_structure(self):
+        tmdl = build_field_parameter_tmdl("Metric", _items())
+        # Three columns: label, Fields, Order.
+        assert "column Metric\n" in tmdl
+        assert "column 'Metric Fields'" in tmdl
+        assert "column 'Metric Order'" in tmdl
+        # Label column is sorted by Order and grouped by Fields.
+        assert "sortByColumn: 'Metric Order'" in tmdl
+        assert "groupByColumn: 'Metric Fields'" in tmdl
+        # ParameterMetadata marks it as a parameter.
+        assert "ParameterMetadata" in tmdl
+        # Calculated partition with NAMEOF rows in order.
+        assert "partition Metric = calculated" in tmdl
+        assert '("Sales", NAMEOF(\'financials\'[Sales]), 0)' in tmdl
+        assert '("Units", NAMEOF(\'financials\'[Units Sold]), 2)' in tmdl
+
+    def test_empty_items_raises(self):
+        with pytest.raises(ValueError):
+            build_field_parameter_tmdl("Metric", [])
+
+    def test_bracket_in_name_raises(self):
+        with pytest.raises(ValueError):
+            build_field_parameter_tmdl("Bad[Name]", _items())
+
+
+class TestAddToProject:
+    def test_writes_table_and_ref(self, tmp_path):
+        pbip = create_project(tmp_path, name="FP", table="financials")
+        result = add_field_parameter(str(pbip), "Metric", _items())
+        assert result["items"] == 3
+
+        sm = tmp_path / "FP" / "FP.SemanticModel"
+        table_file = sm / "definition" / "tables" / "Metric.tmdl"
+        assert table_file.exists()
+        # model.tmdl now references the new table so Desktop loads it.
+        model_tmdl = (sm / "definition" / "model.tmdl").read_text(encoding="utf-8")
+        assert "ref table Metric" in model_tmdl
+
+    def test_no_model_raises(self, tmp_path):
+        # A bare report folder with no *.SemanticModel.
+        (tmp_path / "R.Report").mkdir()
+        with pytest.raises(FileNotFoundError):
+            add_field_parameter(str(tmp_path), "Metric", _items())

--- a/tests/unit/test_filter_builder.py
+++ b/tests/unit/test_filter_builder.py
@@ -52,6 +52,36 @@ def filter_validator():
     return jsonschema.Draft7Validator(container_ref, registry=registry)
 
 
+class TestContainerFieldShape:
+    """The FilterContainer `field` must reference the table via Entity, not a
+    query alias via Source. Desktop blanks an alias-based field on its next save,
+    which then blocks the report from opening (verified live 2026-06-22). The MS
+    schema permits either, so only this behavioural check guards against it."""
+
+    def _field_sourceref(self, fc: dict) -> dict:
+        node = fc["field"].get("Column") or fc["field"].get("Measure")
+        return node["Expression"]["SourceRef"]
+
+    def test_value_filter_field_uses_entity(self):
+        fc = fb.build_value_filter("financials", "Segment", ["Enterprise"])
+        assert self._field_sourceref(fc) == {"Entity": "financials"}
+
+    def test_advanced_filter_field_uses_entity(self):
+        fc = fb.build_advanced_filter("financials", "Profit", [(">=", 0)])
+        assert self._field_sourceref(fc) == {"Entity": "financials"}
+
+    def test_relative_date_field_uses_entity(self):
+        fc = fb.build_relative_date_filter("Calendar", "Date", 30, "Days")
+        assert self._field_sourceref(fc) == {"Entity": "Calendar"}
+
+    def test_where_clause_still_uses_alias(self):
+        # The Where/From body still references the query alias — only the
+        # container field changed.
+        fc = fb.build_value_filter("financials", "Segment", ["Enterprise"])
+        in_col = fc["filter"]["Where"][0]["Condition"]["In"]["Expressions"][0]
+        assert "Source" in in_col["Column"]["Expression"]["SourceRef"]
+
+
 class TestSchemaValidation:
     def test_value_filter_validates(self, filter_validator):
         fc = fb.build_value_filter("financials", "Segment", ["Enterprise", "Government"])

--- a/tests/unit/test_pbir_duplication.py
+++ b/tests/unit/test_pbir_duplication.py
@@ -1,0 +1,129 @@
+"""Unit tests for PBIR page duplication and visual clone/move.
+
+Verifies the copy is fully independent (fresh ids, remapped group / interaction
+references) and that the resulting report still passes structural validation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pbi_cli.backends.pbir_backend import PbirBackend
+from pbi_cli.intelligence.visual_builder import (
+    AGG_SUM,
+    FieldDef,
+    VisualSpec,
+    build_bar_chart,
+    build_card,
+)
+from pbi_cli.pbir_validate import validate_report
+
+
+@pytest.fixture()
+def backend(tmp_path) -> PbirBackend:
+    (tmp_path / "T.Report").mkdir()
+    b = PbirBackend(str(tmp_path))
+    b._write_ga_report_json()
+    return b
+
+
+def _col(p: str) -> FieldDef:
+    return FieldDef(entity="financials", property=p, agg=None)
+
+
+def _meas(p: str) -> FieldDef:
+    return FieldDef(entity="financials", property=p, agg=AGG_SUM)
+
+
+def _add_card(b, page) -> str:
+    spec = VisualSpec("card", build_card(_meas("Sales")), 0, 0, 200, 120)
+    return b.visual_add(page, spec)["name"]
+
+
+def _add_bar(b, page) -> str:
+    spec = VisualSpec(
+        "barChart", build_bar_chart(_col("Country"), _meas("Sales")), 0, 200, 400, 300
+    )
+    return b.visual_add(page, spec)["name"]
+
+
+def _errors(tmp_path):
+    return [f for f in validate_report(str(tmp_path)) if f["severity"] == "error"]
+
+
+class TestPageDuplicate:
+    def test_duplicate_creates_independent_page(self, backend, tmp_path):
+        backend.page_add("Sales")
+        a = _add_card(backend, "Sales")
+        b = _add_bar(backend, "Sales")
+        backend.set_visual_interaction("Sales", a, b, "NoFilter")
+
+        result = backend.page_duplicate("Sales", new_display_name="Sales (copy)")
+        pages = {p["displayName"]: p for p in backend.page_list()}
+        assert "Sales (copy)" in pages
+        assert result["visuals"] == 2
+
+        # New page's visuals have different ids than the source.
+        src_ids = {v["name"] for v in backend.visual_list("Sales")}
+        new_ids = {v["name"] for v in backend.visual_list("Sales (copy)")}
+        assert src_ids.isdisjoint(new_ids)
+        # Still valid (interactions remapped to the new ids, no danglers).
+        assert _errors(tmp_path) == []
+
+    def test_duplicate_remaps_group_membership(self, backend, tmp_path):
+        backend.page_add("G")
+        a = _add_card(backend, "G")
+        b = _add_bar(backend, "G")
+        backend.visual_group_add("G", [a, b], display_name="grp")
+
+        backend.page_duplicate("G")
+        assert _errors(tmp_path) == []  # no dangling parentGroupName
+
+    def test_duplicate_missing_page_raises(self, backend):
+        with pytest.raises(ValueError):
+            backend.page_duplicate("Nope")
+
+
+class TestVisualClone:
+    def test_clone_in_place_offsets(self, backend):
+        backend.page_add("P")
+        name = _add_card(backend, "P")
+        res = backend.visual_clone("P", name, dx=24, dy=24)
+        assert res and res["name"] != name
+        visuals = {v["name"]: v for v in backend.visual_list("P")}
+        assert visuals[res["name"]]["x"] == visuals[name]["x"] + 24
+
+    def test_clone_to_other_page(self, backend, tmp_path):
+        backend.page_add("A")
+        backend.page_add("B")
+        name = _add_bar(backend, "A")
+        res = backend.visual_clone("A", name, target_page="B")
+        assert res and res["page"] == "B"
+        assert any(v["name"] == res["name"] for v in backend.visual_list("B"))
+        assert _errors(tmp_path) == []
+
+    def test_clone_missing_returns_none(self, backend):
+        backend.page_add("P")
+        assert backend.visual_clone("P", "ghost") is None
+
+
+class TestVisualMove:
+    def test_move_keeps_id_and_scrubs_interactions(self, backend, tmp_path):
+        backend.page_add("A")
+        backend.page_add("B")
+        a = _add_card(backend, "A")
+        b = _add_bar(backend, "A")
+        backend.set_visual_interaction("A", a, b, "NoFilter")
+
+        res = backend.visual_move("A", b, "B")
+        assert res and res["name"] == b
+        assert any(v["name"] == b for v in backend.visual_list("B"))
+        assert all(v["name"] != b for v in backend.visual_list("A"))
+        # The interaction referencing the moved visual is gone — no danglers.
+        assert _errors(tmp_path) == []
+
+    def test_move_same_page_raises(self, backend):
+        backend.page_add("A")
+        name = _add_card(backend, "A")
+        with pytest.raises(ValueError):
+            backend.visual_move("A", name, "A")

--- a/tests/unit/test_pbir_validate.py
+++ b/tests/unit/test_pbir_validate.py
@@ -1,0 +1,203 @@
+"""Unit tests for PBIR structural + referential validation (pbi report validate).
+
+Builds synthetic PBIR GA projects in tmp_path via PbirBackend, validates a clean
+project (no findings), then introduces each defect class and asserts the matching
+rule fires. Runs anywhere — no Desktop.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from pbi_cli.backends.pbir_backend import PbirBackend
+from pbi_cli.intelligence.visual_builder import AGG_SUM, FieldDef, VisualSpec, build_card
+from pbi_cli.pbir_validate import validate_report
+
+
+@pytest.fixture()
+def backend(tmp_path) -> PbirBackend:
+    (tmp_path / "T.Report").mkdir()
+    b = PbirBackend(str(tmp_path))
+    b._write_ga_report_json()
+    return b
+
+
+def _fd(prop: str) -> FieldDef:
+    return FieldDef(entity="financials", property=prop, agg=AGG_SUM)
+
+
+def _add_card(b: PbirBackend, page: str) -> str:
+    return b.visual_add(page, VisualSpec("card", build_card(_fd("Sales")), 0, 0, 200, 120))["name"]
+
+
+def _rules(findings) -> set[str]:
+    return {f["rule"] for f in findings}
+
+
+def test_clean_project_has_no_errors(backend, tmp_path):
+    backend.page_add("Overview")
+    _add_card(backend, "Overview")
+    findings = validate_report(str(tmp_path))
+    errors = [f for f in findings if f["severity"] == "error"]
+    assert errors == [], errors
+
+
+def test_missing_report_json_flagged(tmp_path):
+    (tmp_path / "T.Report" / "definition" / "pages").mkdir(parents=True)
+    findings = validate_report(str(tmp_path))
+    assert "pbir.missing-report-json" in _rules(findings)
+
+
+def test_not_ga_format(tmp_path):
+    rd = tmp_path / "Legacy.Report"
+    rd.mkdir()
+    (rd / "report.json").write_text("{}", encoding="utf-8")
+    findings = validate_report(str(tmp_path))
+    assert "pbir.not-ga" in _rules(findings)
+
+
+def test_filterconfig_with_schema_is_error(backend, tmp_path):
+    backend.page_add("Overview")
+    page_dir = backend._ga_find_page_dir("Overview")
+    pj = page_dir / "page.json"
+    data = json.loads(pj.read_text(encoding="utf-8"))
+    data["filterConfig"] = {"$schema": "https://example/x.json", "filters": []}
+    pj.write_text(json.dumps(data), encoding="utf-8")
+
+    findings = validate_report(str(tmp_path))
+    assert "pbir.filterconfig-schema" in _rules(findings)
+    assert any(
+        f["severity"] == "error"
+        for f in findings if f["rule"] == "pbir.filterconfig-schema"
+    )
+
+
+def test_empty_filter_field_sourceref_is_error(backend, tmp_path):
+    # Reproduces the live-Desktop "invalid value" block: a filter whose field
+    # SourceRef is empty (neither Entity nor Source).
+    backend.page_add("Overview")
+    page_dir = backend._ga_find_page_dir("Overview")
+    pj = page_dir / "page.json"
+    data = json.loads(pj.read_text(encoding="utf-8"))
+    data["filterConfig"] = {
+        "filters": [
+            {
+                "name": "f0",
+                "type": "Categorical",
+                "field": {"Column": {"Expression": {"SourceRef": {}}, "Property": "Country"}},
+                "filter": {"Version": 2, "From": [], "Where": []},
+            }
+        ]
+    }
+    pj.write_text(json.dumps(data), encoding="utf-8")
+
+    findings = validate_report(str(tmp_path))
+    assert "pbir.filter-field-sourceref" in _rules(findings)
+    assert any(
+        f["severity"] == "error"
+        for f in findings if f["rule"] == "pbir.filter-field-sourceref"
+    )
+
+
+def test_alias_filter_field_warns(backend, tmp_path):
+    # A field SourceRef that uses a query alias (Source) instead of Entity:
+    # schema-valid, but Desktop corrupts it on save — flag as a warning.
+    backend.page_add("Overview")
+    page_dir = backend._ga_find_page_dir("Overview")
+    pj = page_dir / "page.json"
+    data = json.loads(pj.read_text(encoding="utf-8"))
+    data["filterConfig"] = {
+        "filters": [
+            {
+                "name": "f0",
+                "type": "Categorical",
+                "field": {
+                    "Column": {
+                        "Expression": {"SourceRef": {"Source": "f"}},
+                        "Property": "Segment",
+                    }
+                },
+                "filter": {"Version": 2, "From": [], "Where": []},
+            }
+        ]
+    }
+    pj.write_text(json.dumps(data), encoding="utf-8")
+
+    findings = validate_report(str(tmp_path))
+    assert "pbir.filter-field-alias" in _rules(findings)
+    assert "pbir.filter-field-sourceref" not in _rules(findings)
+
+
+def test_valid_filter_field_sourceref_ok(backend, tmp_path):
+    backend.page_add("Overview")
+    page_dir = backend._ga_find_page_dir("Overview")
+    pj = page_dir / "page.json"
+    data = json.loads(pj.read_text(encoding="utf-8"))
+    data["filterConfig"] = {
+        "filters": [
+            {
+                "name": "f0",
+                "type": "Categorical",
+                "field": {
+                    "Column": {
+                        "Expression": {"SourceRef": {"Entity": "Financials"}},
+                        "Property": "Country",
+                    }
+                },
+                "filter": {"Version": 2, "From": [], "Where": []},
+            }
+        ]
+    }
+    pj.write_text(json.dumps(data), encoding="utf-8")
+
+    assert "pbir.filter-field-sourceref" not in _rules(validate_report(str(tmp_path)))
+
+
+def test_dangling_parent_group_ref(backend, tmp_path):
+    backend.page_add("Overview")
+    name = _add_card(backend, "Overview")
+    vj, data = backend._ga_find_visual_json("Overview", name)
+    data["parentGroupName"] = "nonexistent_group_id"
+    vj.write_text(json.dumps(data), encoding="utf-8")
+
+    findings = validate_report(str(tmp_path))
+    assert "pbir.dangling-group-ref" in _rules(findings)
+
+
+def test_dangling_interaction(backend, tmp_path):
+    backend.page_add("Overview")
+    a = _add_card(backend, "Overview")
+    # Target a visual that doesn't exist.
+    backend.set_visual_interaction("Overview", a, "ghost_visual", "NoFilter")
+    findings = validate_report(str(tmp_path))
+    assert "pbir.dangling-interaction" in _rules(findings)
+
+
+def test_dangling_page_order(backend, tmp_path):
+    backend.page_add("Overview")
+    meta = backend._ga_read_pages_json()
+    meta["pageOrder"].append("ghost_page_id")
+    backend._ga_write_pages_json(meta)
+    findings = validate_report(str(tmp_path))
+    assert "pbir.dangling-page-order" in _rules(findings)
+
+
+def test_dangling_bookmark_item(backend, tmp_path):
+    backend.page_add("Overview")
+    _add_card(backend, "Overview")
+    backend.bookmark_add("View A", page="Overview")
+    meta = backend._ga_read_bookmarks_json()
+    meta["items"].append({"name": "ghost_bookmark"})
+    backend._ga_write_bookmarks_json(meta)
+    findings = validate_report(str(tmp_path))
+    assert "pbir.dangling-bookmark" in _rules(findings)
+
+
+def test_invalid_json_is_error(backend, tmp_path):
+    backend.page_add("Overview")
+    page_dir = backend._ga_find_page_dir("Overview")
+    (page_dir / "page.json").write_text("{ not json", encoding="utf-8")
+    findings = validate_report(str(tmp_path))
+    assert "pbir.invalid-json" in _rules(findings)

--- a/tests/unit/test_pbir_visual_additions.py
+++ b/tests/unit/test_pbir_visual_additions.py
@@ -1,0 +1,162 @@
+"""Unit tests for the new PBIR visual features:
+
+  - AI visual builders (decomposition tree, key influencers, smart narrative, Q&A)
+  - button action wiring (visualLink)
+  - constant reference line
+  - visual introspection (visual get)
+
+Synthetic PBIR GA project in tmp_path — runs anywhere, no Desktop.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pbi_cli.backends.pbir_backend import PbirBackend
+from pbi_cli.intelligence.visual_builder import (
+    AGG_SUM,
+    FieldDef,
+    VisualSpec,
+    build_action_button,
+    build_bar_chart,
+    build_card,
+    build_decomposition_tree,
+    build_key_influencers,
+    build_qna,
+    build_smart_narrative,
+)
+from pbi_cli.pbir_validate import validate_report
+
+
+@pytest.fixture()
+def backend(tmp_path) -> PbirBackend:
+    (tmp_path / "T.Report").mkdir()
+    b = PbirBackend(str(tmp_path))
+    b._write_ga_report_json()
+    return b
+
+
+def _col(p: str) -> FieldDef:
+    return FieldDef(entity="financials", property=p, agg=None)
+
+
+def _meas(p: str) -> FieldDef:
+    return FieldDef(entity="financials", property=p, agg=AGG_SUM)
+
+
+class TestAIBuilders:
+    def test_decomposition_tree_roles(self):
+        body = build_decomposition_tree(_meas("Sales"), [_col("Country"), _col("Segment")])
+        qs = body["query"]["queryState"]
+        assert body["visualType"] == "decompositionTreeVisual"
+        assert len(qs["Analyze"]["projections"]) == 1
+        assert len(qs["Explain"]["projections"]) == 2
+
+    def test_key_influencers_roles(self):
+        body = build_key_influencers(_meas("Profit"), [_col("Segment")])
+        assert body["visualType"] == "keyDrivers"
+        assert "Analyze" in body["query"]["queryState"]
+
+    def test_narrative_and_qna_have_no_query(self):
+        assert build_smart_narrative()["visualType"] == "narrativeVisual"
+        assert "query" not in build_qna()
+
+
+class TestButtonAction:
+    def _button(self, b, page="Home"):
+        b.page_add(page)
+        body = build_action_button(shape="blank", text="Go")
+        return page, b.visual_add(page, VisualSpec(body["visualType"], body, 0, 0, 120, 40))["name"]
+
+    def test_page_navigation_resolves_page_id(self, backend):
+        backend.page_add("Detail")
+        page, name = self._button(backend)
+        assert backend.visual_set_action(page, name, "PageNavigation", target="Detail")
+        info = backend.visual_get(page, name)
+        assert info["action"] == "PageNavigation"
+        # navigationSection must be the page GUID, not the display name.
+        detail_id = next(p["name"] for p in backend.page_list() if p["displayName"] == "Detail")
+        _, data = backend._ga_find_visual_json(page, name)
+        link = data["visual"]["visualContainerObjects"]["visualLink"][0]["properties"]
+        assert link["navigationSection"]["expr"]["Literal"]["Value"] == f"'{detail_id}'"
+
+    def test_bookmark_action(self, backend):
+        page, name = self._button(backend)
+        backend.bookmark_add("Q4 View", page=page, capture=False)
+        assert backend.visual_set_action(page, name, "Bookmark", target="Q4 View")
+        assert backend.visual_get(page, name)["action"] == "Bookmark"
+
+    def test_back_needs_no_target(self, backend):
+        page, name = self._button(backend)
+        assert backend.visual_set_action(page, name, "Back")
+
+    def test_pagenav_without_target_raises(self, backend):
+        page, name = self._button(backend)
+        with pytest.raises(ValueError):
+            backend.visual_set_action(page, name, "PageNavigation")
+
+    def test_bad_action_type_raises(self, backend):
+        page, name = self._button(backend)
+        with pytest.raises(ValueError):
+            backend.visual_set_action(page, name, "Teleport")
+
+
+class TestReferenceLine:
+    def _bar(self, b, page="P"):
+        b.page_add(page)
+        spec = VisualSpec(
+            "barChart", build_bar_chart(_col("Country"), _meas("Sales")), 0, 0, 400, 300
+        )
+        return page, b.visual_add(page, spec)["name"]
+
+    def test_add_reference_line(self, backend, tmp_path):
+        page, name = self._bar(backend)
+        assert backend.visual_add_reference_line(page, name, 1000000, name="Target")
+        _, data = backend._ga_find_visual_json(page, name)
+        lines = data["visual"]["objects"]["referenceLine"]
+        assert len(lines) == 1
+        assert lines[0]["properties"]["value"]["expr"]["Literal"]["Value"] == "1000000D"
+        assert validate_report(str(tmp_path)) == [] or all(
+            f["severity"] != "error" for f in validate_report(str(tmp_path))
+        )
+
+    def test_two_lines_distinct_ids(self, backend):
+        page, name = self._bar(backend)
+        backend.visual_add_reference_line(page, name, 100, name="Low")
+        backend.visual_add_reference_line(page, name, 900, name="High")
+        _, data = backend._ga_find_visual_json(page, name)
+        lines = data["visual"]["objects"]["referenceLine"]
+        assert len({line["selector"]["id"] for line in lines}) == 2
+
+    def test_bad_style_raises(self, backend):
+        page, name = self._bar(backend)
+        with pytest.raises(ValueError):
+            backend.visual_add_reference_line(page, name, 1, style="wavy")
+
+
+class TestVisualGet:
+    def test_get_reports_bindings_and_formatting(self, backend):
+        backend.page_add("P")
+        spec = VisualSpec(
+            "barChart", build_bar_chart(_col("Country"), _meas("Sales")), 0, 0, 400, 300,
+            title="Sales by Country",
+        )
+        name = backend.visual_add("P", spec)["name"]
+        info = backend.visual_get("P", name)
+        assert info["visualType"] == "barChart"
+        assert "Category" in info["bindings"]
+        assert "Y" in info["bindings"]
+        assert "title" in info["containerObjects"]
+        assert info["filters"] == 0
+
+    def test_get_reports_conditional_formatting(self, backend):
+        backend.page_add("P")
+        spec = VisualSpec("card", build_card(_meas("Sales")), 0, 0, 200, 120)
+        name = backend.visual_add("P", spec)["name"]
+        backend.visual_format_data_bar("P", name, "financials", "Sales")
+        info = backend.visual_get("P", name)
+        assert any(cf["property"] == "dataBarEnabled" for cf in info["conditionalFormatting"])
+
+    def test_get_missing_returns_none(self, backend):
+        backend.page_add("P")
+        assert backend.visual_get("P", "ghost") is None


### PR DESCRIPTION
## Summary

Closes the highest-value PBIR maturity gaps and fixes a Desktop-durability bug that live testing surfaced.

### Added
- **`pbi report validate`** — offline structural + referential validator. Encodes the runtime rules Power BI Desktop enforces at reload (e.g. no `$schema` inside an embedded `filterConfig`), cross-file integrity (`pageOrder`, `bookmarks.json` items/children, `parentGroupName`, `visualInteractions`), and schema-version drift vs the registry. `--fail-on` CI gate. New module `pbi_cli.pbir_validate`.
- **Field parameters** — `pbi model field-parameter` generates the model-side calculated table (label / Fields / Order columns + `NAMEOF` constructor + `ParameterMetadata`) and registers it in `model.tmdl`. New module `pbi_cli.intelligence.field_parameter`.
- **Filter scope** — `pbi filter` now takes `--scope page|report|visual` (report → `report.json`, visual → `visual.json`).
- **Page / visual duplication** — `pbi report page-duplicate` (regenerates page + visual ids and remaps group / interaction references), `pbi visual clone`, `pbi visual move`.
- **AI visuals wired up** — `decomptree` / `keyinfluencers` build proper Analyze/Explain bindings; `smartnarrative` / `qanda` add cleanly (previously errored on add).
- **Button actions** — `pbi visual action` wires a `visualLink` (PageNavigation resolves display name → GUID, Bookmark → id, WebUrl/Back/Drill/QnA).
- **`pbi visual get`** — read-side introspection (bindings, formatting, CF, filters, action, sync group, group, mobile).
- **Reference lines** — `pbi visual reference-line` adds a constant Y target line.

### Fixed
- **Filter `field` now uses `SourceRef.Entity` (table), not `SourceRef.Source` (query alias).** An alias-based field is schema-valid and loads on first open, but Desktop cannot resolve it at report/visual scope and **rewrites it to an empty SourceRef on its next save**, blocking reopen. Verified live. The `Where`/`From` body still uses the alias (correct there). Validator gained `pbir.filter-field-alias` (warning) and `pbir.filter-field-sourceref` (error) so `report validate` catches both classes *before* Desktop does.

## Testing
- **Live-verified in Power BI Desktop** against an open report: all features render; the report opens clean after a full close/reopen cycle (the exact path that previously corrupted alias-based filter fields on save).
- **1059 unit tests pass**, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)